### PR TITLE
Add the option to manually sign transactions

### DIFF
--- a/src/BotPlutusInterface/CardanoCLI.hs
+++ b/src/BotPlutusInterface/CardanoCLI.hs
@@ -16,8 +16,9 @@ module BotPlutusInterface.CardanoCLI (
   queryTip,
 ) where
 
-import BotPlutusInterface.Effects (PABEffect, ShellArgs (..), callCommand, uploadDir)
+import BotPlutusInterface.Effects (PABEffect, ShellArgs (..), callCommand, printLog, uploadDir)
 import BotPlutusInterface.Files (
+  DummyPrivKey (FromSKey, FromVKey),
   datumJsonFilePath,
   policyScriptFilePath,
   redeemerJsonFilePath,
@@ -25,7 +26,7 @@ import BotPlutusInterface.Files (
   txFilePath,
   validatorScriptFilePath,
  )
-import BotPlutusInterface.Types (PABConfig, Tip)
+import BotPlutusInterface.Types (LogLevel (Warn), PABConfig, Tip)
 import BotPlutusInterface.UtxoParser qualified as UtxoParser
 import Cardano.Api.Shelley (NetworkId (Mainnet, Testnet), NetworkMagic (..), serialiseAddress)
 import Codec.Serialise qualified as Codec
@@ -53,7 +54,7 @@ import Ledger (Slot (Slot), SlotRange)
 import Ledger qualified
 import Ledger.Ada qualified as Ada
 import Ledger.Address (Address (..))
-import Ledger.Crypto (PubKey, PubKeyHash)
+import Ledger.Crypto (PubKey, PubKeyHash (getPubKeyHash))
 import Ledger.Interval (
   Extended (Finite),
   Interval (Interval),
@@ -197,17 +198,24 @@ buildTx ::
   forall (w :: Type) (effs :: [Type -> Type]).
   Member (PABEffect w) effs =>
   PABConfig ->
+  Map PubKeyHash DummyPrivKey ->
   PubKeyHash ->
   BuildMode ->
   Tx ->
   Eff effs ()
-buildTx pabConf ownPkh buildMode tx =
+buildTx pabConf privKeys ownPkh buildMode tx =
   callCommand @w $ ShellArgs "cardano-cli" opts (const ())
   where
     ownAddr = Ledger.pubKeyHashAddress (Ledger.PaymentPubKeyHash ownPkh) Nothing
+    skeys = Map.filter (\case FromSKey _ -> True; FromVKey _ -> False) privKeys
     requiredSigners =
       concatMap
-        (\pubKey -> ["--required-signer", signingKeyFilePath pabConf (Ledger.pubKeyHash pubKey)])
+        ( \pubKey ->
+            let pkh = Ledger.pubKeyHash pubKey
+             in if Map.member pkh skeys
+                  then ["--required-signer", signingKeyFilePath pabConf pkh]
+                  else ["--required-signer-hash", encodeByteString $ fromBuiltin $ getPubKeyHash pkh]
+        )
         (Map.keys (Ledger.txSignatures tx))
     opts =
       mconcat
@@ -236,26 +244,38 @@ signTx ::
   forall (w :: Type) (effs :: [Type -> Type]).
   Member (PABEffect w) effs =>
   PABConfig ->
+  Map PubKeyHash DummyPrivKey ->
   Tx ->
   [PubKey] ->
-  Eff effs ()
-signTx pabConf tx pubKeys =
-  callCommand @w $
-    ShellArgs
-      "cardano-cli"
-      ( mconcat
-          [ ["transaction", "sign"]
-          , ["--tx-body-file", txFilePath pabConf "raw" tx]
-          , signingKeyFiles
-          , ["--out-file", txFilePath pabConf "signed" tx]
-          ]
-      )
-      (const ())
+  Eff effs (Either Text ())
+signTx pabConf privKeys tx pubKeys =
+  let skeys = Map.filter (\case FromSKey _ -> True; FromVKey _ -> False) privKeys
+   in if all ((`Map.member` skeys) . Ledger.pubKeyHash) pubKeys
+        then callCommand @w $ ShellArgs "cardano-cli" opts (const (Right ()))
+        else do
+          let err =
+                Text.unlines
+                  [ "Not all required signatures have signing key files. Please sign and submit the tx manually:"
+                  , "Tx file: " <> txFilePath pabConf "raw" tx
+                  , "Signatories (pkh): "
+                      <> Text.unwords
+                        (map (encodeByteString . fromBuiltin . getPubKeyHash . Ledger.pubKeyHash) pubKeys)
+                  ]
+          printLog @w Warn (Text.unpack err)
+          pure $ Left err
   where
     signingKeyFiles =
       concatMap
         (\pubKey -> ["--signing-key-file", signingKeyFilePath pabConf (Ledger.pubKeyHash pubKey)])
         pubKeys
+
+    opts =
+      mconcat
+        [ ["transaction", "sign"]
+        , ["--tx-body-file", txFilePath pabConf "raw" tx]
+        , signingKeyFiles
+        , ["--out-file", txFilePath pabConf "signed" tx]
+        ]
 
 -- Signs and writes a tx (uses the tx body written to disk as input)
 submitTx ::

--- a/src/BotPlutusInterface/Contract.hs
+++ b/src/BotPlutusInterface/Contract.hs
@@ -24,6 +24,7 @@ import Control.Monad.Freer.Extras.Modify (raiseEnd)
 import Control.Monad.Freer.Writer (Writer (Tell))
 import Data.Aeson (ToJSON, Value)
 import Data.Default (Default (def))
+import Data.Either (isRight)
 import Data.Kind (Type)
 import Data.Map qualified as Map
 import Data.Row (Row)
@@ -200,14 +201,15 @@ writeBalancedTx contractEnv (Right tx) = do
     Right _ -> do
       let ownPkh = contractEnv.cePABConfig.pcOwnPubKeyHash
       let requiredSigners = Map.keys $ tx ^. Tx.signatures
+      privKeys <- either (error . Text.unpack) id <$> Files.readPrivateKeys @w contractEnv.cePABConfig
 
       CardanoCLI.uploadFiles @w contractEnv.cePABConfig
 
-      CardanoCLI.buildTx @w contractEnv.cePABConfig ownPkh CardanoCLI.BuildAuto tx
-      CardanoCLI.signTx @w contractEnv.cePABConfig tx requiredSigners
+      CardanoCLI.buildTx @w contractEnv.cePABConfig privKeys ownPkh CardanoCLI.BuildAuto tx
+      res <- CardanoCLI.signTx @w contractEnv.cePABConfig privKeys tx requiredSigners
 
       result <-
-        if contractEnv.cePABConfig.pcDryRun
+        if contractEnv.cePABConfig.pcDryRun || isRight res
           then pure Nothing
           else CardanoCLI.submitTx @w contractEnv.cePABConfig tx
 

--- a/src/BotPlutusInterface/Files.hs
+++ b/src/BotPlutusInterface/Files.hs
@@ -2,18 +2,19 @@
 
 module BotPlutusInterface.Files (
   policyScriptFilePath,
+  DummyPrivKey (FromSKey, FromVKey),
   validatorScriptFilePath,
   readPrivateKeys,
   signingKeyFilePath,
   txFilePath,
-  readPrivateKey,
   writeAll,
   writePolicyScriptFile,
   redeemerJsonFilePath,
+  mkDummyPrivateKey,
   writeRedeemerJsonFile,
   writeValidatorScriptFile,
   datumJsonFilePath,
-  fromCardanoPaymentKey,
+  skeyToDummyPrivKey,
   writeDatumJsonFile,
 ) where
 
@@ -27,8 +28,9 @@ import BotPlutusInterface.Effects (
  )
 import BotPlutusInterface.Types (PABConfig)
 import Cardano.Api (
-  AsType (AsPaymentKey, AsSigningKey),
+  AsType (AsPaymentKey, AsSigningKey, AsVerificationKey),
   FileError,
+  Key (VerificationKey),
   PaymentKey,
   SigningKey,
   getVerificationKey,
@@ -58,7 +60,7 @@ import Data.Set qualified as Set
 import Data.Text (Text)
 import Data.Text qualified as Text
 import Ledger qualified
-import Ledger.Crypto (PrivateKey, PubKeyHash (PubKeyHash))
+import Ledger.Crypto (PrivateKey, PubKey (PubKey), PubKeyHash (PubKeyHash))
 import Ledger.Tx (Tx)
 import Ledger.Tx qualified as Tx
 import Ledger.TxId qualified as TxId
@@ -67,12 +69,14 @@ import Plutus.V1.Ledger.Api (
   CurrencySymbol,
   Datum (getDatum),
   DatumHash (..),
+  LedgerBytes (LedgerBytes),
   MintingPolicy,
   Redeemer (getRedeemer),
   RedeemerHash (..),
   Script,
   Validator,
   ValidatorHash (..),
+  toBuiltin,
  )
 import PlutusTx (ToData, toData)
 import PlutusTx.Builtins (fromBuiltin)
@@ -167,50 +171,82 @@ readPrivateKeys ::
   forall (w :: Type) (effs :: [Type -> Type]).
   Member (PABEffect w) effs =>
   PABConfig ->
-  Eff effs (Either Text (Map PubKeyHash PrivateKey))
+  Eff effs (Either Text (Map PubKeyHash DummyPrivKey))
 readPrivateKeys pabConf = do
   files <- listDirectory @w $ Text.unpack pabConf.pcSigningKeyFileDir
   let sKeyFiles =
         map (\filename -> Text.unpack pabConf.pcSigningKeyFileDir ++ "/" ++ filename) $
           filter ("skey" `isExtensionOf`) files
-  privKeys <- mapM (readPrivateKey @w) sKeyFiles
-  pure $ toPrivKeyMap <$> sequence privKeys
+  let vKeyFiles =
+        map (\filename -> Text.unpack pabConf.pcSigningKeyFileDir ++ "/" ++ filename) $
+          filter ("vkey" `isExtensionOf`) files
+  privKeys <- mapM (readSigningKey @w) sKeyFiles
+  privKeys' <- mapM (readVerificationKey @w) vKeyFiles
+  pure $ toPrivKeyMap <$> sequence (privKeys <> privKeys')
   where
-    toPrivKeyMap :: [PrivateKey] -> Map PubKeyHash PrivateKey
+    toPrivKeyMap :: [DummyPrivKey] -> Map PubKeyHash DummyPrivKey
     toPrivKeyMap =
       foldl
         ( \pKeyMap pKey ->
-            let pkh = Ledger.pubKeyHash $ Ledger.toPublicKey pKey
+            let pkh = Ledger.pubKeyHash $ Ledger.toPublicKey $ unDummyPrivateKey pKey
              in Map.insert pkh pKey pKeyMap
         )
         Map.empty
 
-readPrivateKey ::
+data DummyPrivKey
+  = FromSKey PrivateKey
+  | FromVKey PrivateKey
+
+unDummyPrivateKey :: DummyPrivKey -> PrivateKey
+unDummyPrivateKey (FromSKey key) = key
+unDummyPrivateKey (FromVKey key) = key
+
+readSigningKey ::
   forall (w :: Type) (effs :: [Type -> Type]).
   Member (PABEffect w) effs =>
   FilePath ->
-  Eff effs (Either Text PrivateKey)
-readPrivateKey filePath = do
+  Eff effs (Either Text DummyPrivKey)
+readSigningKey filePath = do
   pKey <- mapLeft (Text.pack . show) <$> readFileTextEnvelope @w (AsSigningKey AsPaymentKey) filePath
-  pure $ fromCardanoPaymentKey =<< pKey
+  pure $ skeyToDummyPrivKey =<< pKey
+
+readVerificationKey ::
+  forall (w :: Type) (effs :: [Type -> Type]).
+  Member (PABEffect w) effs =>
+  FilePath ->
+  Eff effs (Either Text DummyPrivKey)
+readVerificationKey filePath = do
+  pKey <- mapLeft (Text.pack . show) <$> readFileTextEnvelope @w (AsVerificationKey AsPaymentKey) filePath
+  pure $ vkeyToDummyPrivKey =<< pKey
+
+vkeyToDummyPrivKey :: VerificationKey PaymentKey -> Either Text DummyPrivKey
+vkeyToDummyPrivKey =
+  fmap FromVKey . vkeyToDummyPrivKey'
+
+skeyToDummyPrivKey :: SigningKey PaymentKey -> Either Text DummyPrivKey
+skeyToDummyPrivKey =
+  fmap FromSKey . vkeyToDummyPrivKey' . getVerificationKey
 
 {- | Warning! This implementation is not correct!
  This private key is derived from a normal signing key which uses a 32 byte private key compared
  to the extended key which is 64 bytes. Also, the extended key includes a chain index value
 
- This keys sole purpose is to be able to derive a public key from it, which is then used for
+ This key's sole purpose is to be able to derive a public key from it, which is then used for
  mapping to a signing key file for the CLI
 -}
-fromCardanoPaymentKey :: SigningKey PaymentKey -> Either Text PrivateKey
-fromCardanoPaymentKey sKey =
-  let dummyPrivKeySuffix = ByteString.replicate 32 0
+vkeyToDummyPrivKey' :: VerificationKey PaymentKey -> Either Text PrivateKey
+vkeyToDummyPrivKey' =
+  mkDummyPrivateKey . PubKey . LedgerBytes . toBuiltin . serialiseToRawBytes
+
+mkDummyPrivateKey :: PubKey -> Either Text PrivateKey
+mkDummyPrivateKey (PubKey (LedgerBytes pubkey)) =
+  let dummyPrivKey = ByteString.replicate 32 0
+      dummyPrivKeySuffix = ByteString.replicate 32 0
       dummyChainCode = ByteString.replicate 32 1
-      vKey = getVerificationKey sKey
-      privkeyBS = serialiseToRawBytes sKey
-      pubkeyBS = serialiseToRawBytes vKey
+      pubkeyBS = fromBuiltin pubkey
    in mapLeft Text.pack $
         Crypto.xprv $
-          mconcat [privkeyBS, dummyPrivKeySuffix, pubkeyBS, dummyChainCode]
+          mconcat [dummyPrivKey, dummyPrivKeySuffix, pubkeyBS, dummyChainCode]
 
 serialiseScript :: Script -> PlutusScript PlutusScriptV1
 serialiseScript =

--- a/src/BotPlutusInterface/Files.hs
+++ b/src/BotPlutusInterface/Files.hs
@@ -83,7 +83,7 @@ import Plutus.V1.Ledger.Api (
  )
 import PlutusTx (ToData, toData)
 import PlutusTx.Builtins (fromBuiltin)
-import System.FilePath (isExtensionOf, (</>))
+import System.FilePath (takeExtension, (</>))
 import Prelude
 
 -- | Filename of a minting policy script
@@ -183,11 +183,10 @@ readPrivateKeys pabConf = do
       <$> mapM
         ( \filename ->
             let fullPath = Text.unpack pabConf.pcSigningKeyFileDir </> filename
-             in case filename of
-                  _
-                    | "vkey" `isExtensionOf` filename -> Just <$> readVerificationKey @w fullPath
-                    | "skey" `isExtensionOf` filename -> Just <$> readSigningKey @w fullPath
-                    | otherwise -> pure Nothing
+             in case takeExtension filename of
+                     ".vkey" -> Just <$> readVerificationKey @w fullPath
+                     ".skey" -> Just <$> readSigningKey @w fullPath
+                     _ -> pure Nothing
         )
         files
 

--- a/src/BotPlutusInterface/Files.hs
+++ b/src/BotPlutusInterface/Files.hs
@@ -16,6 +16,7 @@ module BotPlutusInterface.Files (
   writeValidatorScriptFile,
   datumJsonFilePath,
   skeyToDummyPrivKey,
+  vkeyToDummyPrivKey,
   writeDatumJsonFile,
 ) where
 

--- a/src/BotPlutusInterface/Files.hs
+++ b/src/BotPlutusInterface/Files.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
-{-# LANGUAGE MultiWayIf #-}
 
 module BotPlutusInterface.Files (
   policyScriptFilePath,

--- a/src/BotPlutusInterface/Files.hs
+++ b/src/BotPlutusInterface/Files.hs
@@ -184,9 +184,9 @@ readPrivateKeys pabConf = do
         ( \filename ->
             let fullPath = Text.unpack pabConf.pcSigningKeyFileDir </> filename
              in case takeExtension filename of
-                     ".vkey" -> Just <$> readVerificationKey @w fullPath
-                     ".skey" -> Just <$> readSigningKey @w fullPath
-                     _ -> pure Nothing
+                  ".vkey" -> Just <$> readVerificationKey @w fullPath
+                  ".skey" -> Just <$> readSigningKey @w fullPath
+                  _ -> pure Nothing
         )
         files
 

--- a/src/BotPlutusInterface/Files.hs
+++ b/src/BotPlutusInterface/Files.hs
@@ -3,6 +3,7 @@
 module BotPlutusInterface.Files (
   policyScriptFilePath,
   DummyPrivKey (FromSKey, FromVKey),
+  unDummyPrivateKey,
   validatorScriptFilePath,
   readPrivateKeys,
   signingKeyFilePath,

--- a/src/BotPlutusInterface/Files.hs
+++ b/src/BotPlutusInterface/Files.hs
@@ -175,14 +175,14 @@ readPrivateKeys ::
   Eff effs (Either Text (Map PubKeyHash DummyPrivKey))
 readPrivateKeys pabConf = do
   files <- listDirectory @w $ Text.unpack pabConf.pcSigningKeyFileDir
-  let sKeyFiles =
-        map (\filename -> Text.unpack pabConf.pcSigningKeyFileDir ++ "/" ++ filename) $
-          filter ("skey" `isExtensionOf`) files
   let vKeyFiles =
         map (\filename -> Text.unpack pabConf.pcSigningKeyFileDir ++ "/" ++ filename) $
           filter ("vkey" `isExtensionOf`) files
-  privKeys <- mapM (readSigningKey @w) sKeyFiles
-  privKeys' <- mapM (readVerificationKey @w) vKeyFiles
+  let sKeyFiles =
+        map (\filename -> Text.unpack pabConf.pcSigningKeyFileDir ++ "/" ++ filename) $
+          filter ("skey" `isExtensionOf`) files
+  privKeys <- mapM (readVerificationKey @w) vKeyFiles
+  privKeys' <- mapM (readSigningKey @w) sKeyFiles
   pure $ toPrivKeyMap <$> sequence (privKeys <> privKeys')
   where
     toPrivKeyMap :: [DummyPrivKey] -> Map PubKeyHash DummyPrivKey

--- a/src/BotPlutusInterface/PreBalance.hs
+++ b/src/BotPlutusInterface/PreBalance.hs
@@ -7,7 +7,7 @@ module BotPlutusInterface.PreBalance (
 
 import BotPlutusInterface.CardanoCLI qualified as CardanoCLI
 import BotPlutusInterface.Effects (PABEffect, createDirectoryIfMissing, printLog)
-import BotPlutusInterface.Files (DummyPrivKey (FromSKey, FromVKey))
+import BotPlutusInterface.Files (DummyPrivKey, unDummyPrivateKey)
 import BotPlutusInterface.Files qualified as Files
 import BotPlutusInterface.Types (LogLevel (Debug), PABConfig)
 import Cardano.Api.Shelley (Lovelace (Lovelace), ProtocolParameters (protocolParamUTxOCostPerWord))
@@ -267,8 +267,7 @@ addSignatories ownPkh privKeys pkhs tx =
   foldM
     ( \tx' pkh ->
         case Map.lookup pkh privKeys of
-          Just (FromSKey privKey) -> Right $ Tx.addSignature' privKey tx'
-          Just (FromVKey privKey) -> Right $ Tx.addSignature' privKey tx'
+          Just privKey -> Right $ Tx.addSignature' (unDummyPrivateKey privKey) tx'
           Nothing -> Left "Signing key not found."
     )
     tx

--- a/test/Spec/BotPlutusInterface/Contract.hs
+++ b/test/Spec/BotPlutusInterface/Contract.hs
@@ -311,7 +311,8 @@ withoutSigning = do
       initState =
         def
           & utxos .~ [(txOutRef, txOut)]
-          & files .~ uncurry Map.singleton (toVerificationKeyFile "./signing-keys" verificationKey1)
+          & files
+            .~ Map.fromList [toVerificationKeyFile "./signing-keys" verificationKey1]
       inTxId = encodeByteString $ fromBuiltin $ TxId.getTxId $ Tx.txOutRefId txOutRef
 
       contract :: Contract Text (Endpoint "SendAda" ()) Text CardanoTx

--- a/test/Spec/BotPlutusInterface/PreBalance.hs
+++ b/test/Spec/BotPlutusInterface/PreBalance.hs
@@ -1,5 +1,6 @@
 module Spec.BotPlutusInterface.PreBalance (tests) where
 
+import BotPlutusInterface.Files (DummyPrivKey (FromSKey))
 import BotPlutusInterface.PreBalance qualified as PreBalance
 import Cardano.Api.Shelley (Lovelace (Lovelace), ProtocolParameters (protocolParamUTxOCostPerWord))
 import Data.Default (def)
@@ -10,7 +11,7 @@ import Ledger.Ada qualified as Ada
 import Ledger.Address (Address, PaymentPubKeyHash (PaymentPubKeyHash))
 import Ledger.Address qualified as Address
 import Ledger.CardanoWallet qualified as Wallet
-import Ledger.Crypto (PrivateKey, PubKeyHash)
+import Ledger.Crypto (PubKeyHash)
 import Ledger.Tx (Tx (..), TxIn (..), TxInType (..), TxOut (..), TxOutRef (..))
 import Ledger.Value qualified as Value
 import Test.Tasty (TestTree, testGroup)
@@ -30,8 +31,8 @@ tests =
     , testCase "Add utxos to cover change min utxo" addUtxosForChange
     ]
 
-privateKey1 :: PrivateKey
-privateKey1 = Address.unPaymentPrivateKey . Wallet.paymentPrivateKey $ Wallet.knownMockWallet 1
+privateKey1 :: DummyPrivKey
+privateKey1 = FromSKey . Address.unPaymentPrivateKey . Wallet.paymentPrivateKey $ Wallet.knownMockWallet 1
 
 pkh1, pkh2 :: PubKeyHash
 pkh1 = Address.unPaymentPubKeyHash . Wallet.paymentPubKeyHash $ Wallet.knownMockWallet 1

--- a/test/Spec/MockContract.hs
+++ b/test/Spec/MockContract.hs
@@ -85,7 +85,7 @@ import Data.Aeson qualified as JSON
 import Data.Aeson.Extras (encodeByteString)
 import Data.ByteString qualified as ByteString
 import Data.Default (Default (def))
-import Data.Either.Combinators (fromRight, mapLeft)
+import Data.Either.Combinators (mapLeft)
 import Data.Hex (hex)
 import Data.Kind (Type)
 import Data.List (isPrefixOf)
@@ -164,14 +164,14 @@ skeyToPubKey :: SigningKey PaymentKey -> PubKey
 skeyToPubKey =
   Ledger.toPublicKey
     . Files.unDummyPrivateKey
-    . fromRight (error "Impossible happened")
+    . either (error . Text.unpack) id
     . Files.skeyToDummyPrivKey
 
 vkeyToPubKey :: VerificationKey PaymentKey -> PubKey
 vkeyToPubKey =
   Ledger.toPublicKey
     . Files.unDummyPrivateKey
-    . fromRight (error "Impossible happened")
+    . either (error . Text.unpack) id
     . Files.vkeyToDummyPrivKey
 
 toSigningKeyFile :: FilePath -> SigningKey PaymentKey -> (FilePath, MockFile)

--- a/test/Spec/MockContract.hs
+++ b/test/Spec/MockContract.hs
@@ -147,7 +147,11 @@ addr2 = unsafeSerialiseAddress Mainnet (Ledger.pubKeyHashAddress paymentPkh2 Not
 addr3 = unsafeSerialiseAddress Mainnet (Ledger.pubKeyHashAddress paymentPkh3 Nothing)
 
 toPubKey :: SigningKey PaymentKey -> PubKey
-toPubKey = Ledger.toPublicKey . fromRight (error "Impossible happened") . Files.fromCardanoPaymentKey
+toPubKey =
+  Ledger.toPublicKey
+    . Files.unDummyPrivateKey
+    . fromRight (error "Impossible happened")
+    . Files.skeyToDummyPrivKey
 
 toSigningKeyFile :: FilePath -> SigningKey PaymentKey -> (FilePath, MockFile)
 toSigningKeyFile signingKeyFileDir sKey =

--- a/test/Spec/MockContract.hs
+++ b/test/Spec/MockContract.hs
@@ -4,12 +4,15 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Spec.MockContract (
+  -- Mock private and public keys etc.
   signingKey1,
   signingKey2,
-  runContractPure,
+  signingKey3,
+  verificationKey1,
+  verificationKey2,
+  verificationKey3,
   toSigningKeyFile,
-  runContractPure',
-  MockContractState (..),
+  toVerificationKeyFile,
   pubKey1,
   pubKey2,
   pubKey3,
@@ -28,6 +31,10 @@ module Spec.MockContract (
   pkhAddr1,
   pkhAddr2,
   pkhAddr3,
+  -- Test interpreter
+  runContractPure,
+  runContractPure',
+  MockContractState (..),
   commandHistory,
   instanceUpdateHistory,
   logHistory,
@@ -52,6 +59,7 @@ import Cardano.Api (
   AsType,
   FileError (FileError, FileIOError),
   HasTextEnvelope,
+  Key (VerificationKey, getVerificationKey),
   NetworkId (Mainnet),
   PaymentKey,
   SigningKey (PaymentSigningKey),
@@ -59,6 +67,7 @@ import Cardano.Api (
   TextEnvelopeDescr,
   TextEnvelopeError (TextEnvelopeAesonDecodeError),
   deserialiseFromTextEnvelope,
+  getVerificationKey,
   serialiseToTextEnvelope,
  )
 import Cardano.Crypto.DSIGN (genKeyDSIGN)
@@ -116,10 +125,15 @@ signingKey1 = PaymentSigningKey $ genKeyDSIGN $ mkSeedFromBytes $ ByteString.rep
 signingKey2 = PaymentSigningKey $ genKeyDSIGN $ mkSeedFromBytes $ ByteString.replicate 32 1
 signingKey3 = PaymentSigningKey $ genKeyDSIGN $ mkSeedFromBytes $ ByteString.replicate 32 2
 
+verificationKey1, verificationKey2, verificationKey3 :: VerificationKey PaymentKey
+verificationKey1 = getVerificationKey signingKey1
+verificationKey2 = getVerificationKey signingKey2
+verificationKey3 = getVerificationKey signingKey3
+
 pubKey1, pubKey2, pubKey3 :: PubKey
-pubKey1 = toPubKey signingKey1
-pubKey2 = toPubKey signingKey2
-pubKey3 = toPubKey signingKey3
+pubKey1 = skeyToPubKey signingKey1
+pubKey2 = skeyToPubKey signingKey2
+pubKey3 = skeyToPubKey signingKey3
 
 pkh1, pkh2, pkh3 :: PubKeyHash
 pkh1 = Ledger.pubKeyHash pubKey1
@@ -146,17 +160,30 @@ addr1 = unsafeSerialiseAddress Mainnet (Ledger.pubKeyHashAddress paymentPkh1 Not
 addr2 = unsafeSerialiseAddress Mainnet (Ledger.pubKeyHashAddress paymentPkh2 Nothing)
 addr3 = unsafeSerialiseAddress Mainnet (Ledger.pubKeyHashAddress paymentPkh3 Nothing)
 
-toPubKey :: SigningKey PaymentKey -> PubKey
-toPubKey =
+skeyToPubKey :: SigningKey PaymentKey -> PubKey
+skeyToPubKey =
   Ledger.toPublicKey
     . Files.unDummyPrivateKey
     . fromRight (error "Impossible happened")
     . Files.skeyToDummyPrivKey
 
+vkeyToPubKey :: VerificationKey PaymentKey -> PubKey
+vkeyToPubKey =
+  Ledger.toPublicKey
+    . Files.unDummyPrivateKey
+    . fromRight (error "Impossible happened")
+    . Files.vkeyToDummyPrivKey
+
 toSigningKeyFile :: FilePath -> SigningKey PaymentKey -> (FilePath, MockFile)
 toSigningKeyFile signingKeyFileDir sKey =
-  ( signingKeyFileDir ++ "/signing-key-" ++ show (Ledger.pubKeyHash (toPubKey sKey)) ++ ".skey"
+  ( signingKeyFileDir ++ "/signing-key-" ++ show (Ledger.pubKeyHash (skeyToPubKey sKey)) ++ ".skey"
   , TextEnvelopeFile $ serialiseToTextEnvelope Nothing sKey
+  )
+
+toVerificationKeyFile :: FilePath -> VerificationKey PaymentKey -> (FilePath, MockFile)
+toVerificationKeyFile signingKeyFileDir vKey =
+  ( signingKeyFileDir ++ "/signing-key-" ++ show (Ledger.pubKeyHash (vkeyToPubKey vKey)) ++ ".vkey"
+  , TextEnvelopeFile $ serialiseToTextEnvelope Nothing vKey
   )
 
 data MockFile


### PR DESCRIPTION
Based on: #42

This PR introduces a way to delay the signing of transactions. This could be useful when we don't want to store the signing key(s) on the bot server. We still need their verification keys, in the same folder and in the same format as the signing keys, only with a `vkey` file extension.
