### PR TITLE
Fully internalise balancing, fix tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,13 +125,13 @@ The fake PAB consists of the following modules:
 - **BotPlutusInterface** main entry point
 - **BotPlutusInterface.Server** Servant server, handling http endpoint calls and websockets
 - **BotPlutusInterface.Contract** handling contract effects by creating the necessary files and calling cardano-cli commands (a few effects are mocked)
-- **BotPlutusInterface.PreBalance** doing some preparations so the cli can process the rest (non-ada asset balancing, addig tx inputs, adding minimum lovelaces, add signatories)
+- **BotPlutusInterface.Balance** doing some preparations so the cli can process the rest (non-ada asset balancing, addig tx inputs, adding minimum lovelaces, add signatories)
 - **BotPlutusInterface.CardanoCLI** wrappers for cardano-cli commands
 - For development purposes, I created an ssh wrapper, so I can call relay these commands through an ssh connection. This is not nice, unsafe, and pretty slow, avoid using it if you can.
 - **BotPlutusInterface.UtxoParser** parse the output of the `cardano-cli query utxo` command
 - **BotPlutusInterface.Files** functions for handling script, datum and redeemer files
 - **BotPlutusInterface.Types** configuration for the fake pab
-- **BotPlutusInterface.PreBalance** prepare a transaction before sending to the cli for balancing. This includes:
+- **BotPlutusInterface.Balance** prepare a transaction before sending to the cli for balancing. This includes:
   - adding tx inputs to cover fees and outputs
   - adding collaterals,
   - modifying tx outs to contain the minimum amount of lovelaces

--- a/bot-plutus-interface.cabal
+++ b/bot-plutus-interface.cabal
@@ -81,7 +81,7 @@ library
     BotPlutusInterface.Contract
     BotPlutusInterface.Effects
     BotPlutusInterface.Files
-    BotPlutusInterface.PreBalance
+    BotPlutusInterface.Balance
     BotPlutusInterface.Types
     BotPlutusInterface.UtxoParser
 
@@ -143,7 +143,7 @@ test-suite bot-plutus-interface-test
   ghc-options:    -fplugin-opt PlutusTx.Plugin:defer-errors
   other-modules:
     Spec.BotPlutusInterface.Contract
-    Spec.BotPlutusInterface.PreBalance
+    Spec.BotPlutusInterface.Balance
     Spec.BotPlutusInterface.UtxoParser
     Spec.MockContract
 

--- a/src/BotPlutusInterface/Contract.hs
+++ b/src/BotPlutusInterface/Contract.hs
@@ -135,7 +135,7 @@ handlePABReq contractEnv req = do
     ChainIndexQueryReq query ->
       ChainIndexQueryResp <$> queryChainIndex @w query
     BalanceTxReq unbalancedTx ->
-      BalanceTxResp <$> balanceTxStep @w contractEnv unbalancedTx
+      BalanceTxResp <$> balanceTx @w contractEnv unbalancedTx
     WriteBalancedTxReq tx ->
       WriteBalancedTxResp <$> writeBalancedTx @w contractEnv tx
     AwaitSlotReq s -> AwaitSlotResp <$> awaitSlot @w contractEnv s
@@ -162,14 +162,14 @@ handlePABReq contractEnv req = do
   printLog @w Debug $ show resp
   pure resp
 
--- | This is not identical to the real balancing, we only do a pre-balance at this stage
-balanceTxStep ::
+-- | This will FULLY balance a transaction
+balanceTx ::
   forall (w :: Type) (effs :: [Type -> Type]).
   Member (PABEffect w) effs =>
   ContractEnvironment w ->
   UnbalancedTx ->
   Eff effs BalanceTxResponse
-balanceTxStep contractEnv unbalancedTx = do
+balanceTx contractEnv unbalancedTx = do
   eitherPreBalancedTx <-
     PreBalance.balanceTxIO @w
       contractEnv.cePABConfig

--- a/src/BotPlutusInterface/Contract.hs
+++ b/src/BotPlutusInterface/Contract.hs
@@ -3,6 +3,7 @@
 
 module BotPlutusInterface.Contract (runContract, handleContract) where
 
+import BotPlutusInterface.Balance qualified as PreBalance
 import BotPlutusInterface.CardanoCLI qualified as CardanoCLI
 import BotPlutusInterface.Effects (
   PABEffect,
@@ -15,7 +16,6 @@ import BotPlutusInterface.Effects (
  )
 import BotPlutusInterface.Files (DummyPrivKey (FromSKey, FromVKey))
 import BotPlutusInterface.Files qualified as Files
-import BotPlutusInterface.PreBalance qualified as PreBalance
 import BotPlutusInterface.Types (ContractEnvironment (..), LogLevel (Debug, Warn), Tip (slot))
 import Control.Lens ((^.))
 import Control.Monad (void)
@@ -135,7 +135,7 @@ handlePABReq contractEnv req = do
     ChainIndexQueryReq query ->
       ChainIndexQueryResp <$> queryChainIndex @w query
     BalanceTxReq unbalancedTx ->
-      BalanceTxResp <$> balanceTx @w contractEnv unbalancedTx
+      BalanceTxResp <$> balanceTxStep @w contractEnv unbalancedTx
     WriteBalancedTxReq tx ->
       WriteBalancedTxResp <$> writeBalancedTx @w contractEnv tx
     AwaitSlotReq s -> AwaitSlotResp <$> awaitSlot @w contractEnv s
@@ -163,15 +163,15 @@ handlePABReq contractEnv req = do
   pure resp
 
 -- | This is not identical to the real balancing, we only do a pre-balance at this stage
-balanceTx ::
+balanceTxStep ::
   forall (w :: Type) (effs :: [Type -> Type]).
   Member (PABEffect w) effs =>
   ContractEnvironment w ->
   UnbalancedTx ->
   Eff effs BalanceTxResponse
-balanceTx contractEnv unbalancedTx = do
+balanceTxStep contractEnv unbalancedTx = do
   eitherPreBalancedTx <-
-    PreBalance.preBalanceTxIO @w
+    PreBalance.balanceTxIO @w
       contractEnv.cePABConfig
       (contractEnv.cePABConfig.pcOwnPubKeyHash)
       unbalancedTx
@@ -194,14 +194,13 @@ writeBalancedTx contractEnv (Right tx) = do
     void $ firstEitherT (Text.pack . show) $ newEitherT $ Files.writeAll @w pabConf tx
     privKeys <- newEitherT $ Files.readPrivateKeys @w pabConf
 
-    let ownPkh = pabConf.pcOwnPubKeyHash
     let requiredSigners = Map.keys $ tx ^. Tx.signatures
-    let skeys = Map.filter (\case FromSKey _ -> True; FromVKey _ -> False) privKeys
-    let signable = all ((`Map.member` skeys) . Ledger.pubKeyHash) requiredSigners
+        skeys = Map.filter (\case FromSKey _ -> True; FromVKey _ -> False) privKeys
+        signable = all ((`Map.member` skeys) . Ledger.pubKeyHash) requiredSigners
 
     lift $ CardanoCLI.uploadFiles @w pabConf
 
-    newEitherT $ CardanoCLI.buildTx @w pabConf privKeys ownPkh CardanoCLI.BuildAuto tx
+    newEitherT $ CardanoCLI.buildTx @w pabConf privKeys tx
 
     if signable
       then newEitherT $ CardanoCLI.signTx @w pabConf tx requiredSigners

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,8 +1,8 @@
 module Main (main) where
 
 import Spec.BotPlutusInterface.Balance qualified
-import Spec.BotPlutusInterface.Server qualified
 import Spec.BotPlutusInterface.Contract qualified
+import Spec.BotPlutusInterface.Server qualified
 import Spec.BotPlutusInterface.UtxoParser qualified
 import Test.Tasty (TestTree, defaultMain, testGroup)
 import Prelude

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,7 +1,7 @@
 module Main (main) where
 
+import Spec.BotPlutusInterface.Balance qualified
 import Spec.BotPlutusInterface.Contract qualified
-import Spec.BotPlutusInterface.PreBalance qualified
 import Spec.BotPlutusInterface.UtxoParser qualified
 import Test.Tasty (TestTree, defaultMain, testGroup)
 import Prelude
@@ -20,5 +20,5 @@ tests =
     "BotPlutusInterface"
     [ Spec.BotPlutusInterface.Contract.tests
     , Spec.BotPlutusInterface.UtxoParser.tests
-    , Spec.BotPlutusInterface.PreBalance.tests
+    , Spec.BotPlutusInterface.Balance.tests
     ]

--- a/test/Spec/BotPlutusInterface/Balance.hs
+++ b/test/Spec/BotPlutusInterface/Balance.hs
@@ -1,5 +1,6 @@
 module Spec.BotPlutusInterface.Balance (tests) where
 
+import BotPlutusInterface.Balance (withFee)
 import BotPlutusInterface.Balance qualified as Balance
 import Data.Map qualified as Map
 import Data.Set qualified as Set
@@ -57,38 +58,35 @@ utxo4 = (txOutRef4, TxOut addr1 (Ada.lovelaceValueOf 800_000 <> Value.singleton 
 addUtxosForFees :: Assertion
 addUtxosForFees = do
   let txout = TxOut addr2 (Ada.lovelaceValueOf 1_000_000) Nothing
-      tx = mempty {txOutputs = [txout]}
+      tx = mempty {txOutputs = [txout]} `withFee` 500_000
       minUtxo = [(txout, 1_000_000)]
-      fees = 500_000
       utxoIndex = Map.fromList [utxo1, utxo2, utxo3]
       ownPkh = pkh1
       balancedTx =
-        Balance.balanceTxStep minUtxo fees utxoIndex ownPkh tx
+        Balance.balanceTxStep minUtxo utxoIndex ownPkh tx
 
   txInputs <$> balancedTx @?= Right (Set.fromList [txIn1, txIn2])
 
 addUtxosForNativeTokens :: Assertion
 addUtxosForNativeTokens = do
   let txout = TxOut addr2 (Value.singleton "11223344" "Token" 123) Nothing
-      tx = mempty {txOutputs = [txout]}
+      tx = mempty {txOutputs = [txout]} `withFee` 500_000
       minUtxo = [(txout, 1_000_000)]
-      fees = 500_000
       utxoIndex = Map.fromList [utxo1, utxo2, utxo3, utxo4]
       ownPkh = pkh1
       balancedTx =
-        Balance.balanceTxStep minUtxo fees utxoIndex ownPkh tx
+        Balance.balanceTxStep minUtxo utxoIndex ownPkh tx
 
   txInputs <$> balancedTx @?= Right (Set.fromList [txIn1, txIn2, txIn3, txIn4])
 
 addUtxosForChange :: Assertion
 addUtxosForChange = do
   let txout = TxOut addr2 (Ada.lovelaceValueOf 1_600_000) Nothing
-      tx = mempty {txOutputs = [txout]}
+      tx = mempty {txOutputs = [txout]} `withFee` 500_000
       minUtxo = [(txout, 1_000_000)]
-      fees = 500_000
       utxoIndex = Map.fromList [utxo1, utxo2, utxo3]
       ownPkh = pkh1
       balancedTx =
-        Balance.balanceTxStep minUtxo fees utxoIndex ownPkh tx
+        Balance.balanceTxStep minUtxo utxoIndex ownPkh tx
 
   txInputs <$> balancedTx @?= Right (Set.fromList [txIn1, txIn2])

--- a/test/Spec/BotPlutusInterface/Contract.hs
+++ b/test/Spec/BotPlutusInterface/Contract.hs
@@ -897,11 +897,15 @@ assertCommandHistory state =
           (fromMaybe "" $ state ^? commandHistory . ix idx)
     )
 
+-- | assertEqual but using `commandEqual`
 assertCommandEqual :: String -> Text -> Text -> Assertion
 assertCommandEqual err expected actual
   | commandEqual expected actual = return ()
   | otherwise = assertFailure $ err ++ "\nExpected:\n" ++ show expected ++ "\nGot:\n" ++ show actual
 
+-- | Checks if a command matches an expected command pattern
+-- Where a command pattern may use new lines in place of spaces, and use the wildcard `?` to match up to the next space
+-- E.g. `commandEqual "123\n456 ? 0" "123 456 789 0"` == `True`
 commandEqual :: Text -> Text -> Bool
 commandEqual "" "" = True
 commandEqual "" _ = False

--- a/test/Spec/BotPlutusInterface/Contract.hs
+++ b/test/Spec/BotPlutusInterface/Contract.hs
@@ -8,6 +8,7 @@ import Cardano.Api (NetworkId (Mainnet))
 import Control.Lens (ix, (&), (.~), (^.), (^?))
 import Data.Aeson (ToJSON)
 import Data.Aeson.Extras (encodeByteString)
+import Data.Char (isSpace)
 import Data.Default (def)
 import Data.Function (on)
 import Data.Kind (Type)
@@ -892,7 +893,7 @@ assertCommandHistory state =
     ( \(idx, expectedCmd) ->
         assertCommandEqual
           ("command at index " ++ show idx ++ " was incorrect:")
-          (Text.replace "\n" " " expectedCmd)
+          expectedCmd
           (fromMaybe "" $ state ^? commandHistory . ix idx)
     )
 
@@ -908,8 +909,8 @@ commandEqual _ "" = False
 commandEqual expected actual = maybe False (on commandEqual dropToSpace postExp) mPostAct
   where
     (preExp, postExp) = Text.breakOn "?" expected
-    mPostAct = Text.stripPrefix preExp actual
-    dropToSpace = Text.dropWhile (/= ' ')
+    mPostAct = Text.stripPrefix (Text.replace "\n" " " preExp) actual
+    dropToSpace = Text.dropWhile (not . isSpace)
 
 assertCommandCalled :: forall (w :: Type). MockContractState w -> Text -> Assertion
 assertCommandCalled state expectedCmd =

--- a/test/Spec/BotPlutusInterface/Contract.hs
+++ b/test/Spec/BotPlutusInterface/Contract.hs
@@ -903,9 +903,10 @@ assertCommandEqual err expected actual
   | commandEqual expected actual = return ()
   | otherwise = assertFailure $ err ++ "\nExpected:\n" ++ show expected ++ "\nGot:\n" ++ show actual
 
--- | Checks if a command matches an expected command pattern
--- Where a command pattern may use new lines in place of spaces, and use the wildcard `?` to match up to the next space
--- E.g. `commandEqual "123\n456 ? 0" "123 456 789 0"` == `True`
+{- | Checks if a command matches an expected command pattern
+ Where a command pattern may use new lines in place of spaces, and use the wildcard `?` to match up to the next space
+ E.g. `commandEqual "123\n456 ? 0" "123 456 789 0"` == `True`
+-}
 commandEqual :: Text -> Text -> Bool
 commandEqual "" "" = True
 commandEqual "" _ = False

--- a/test/Spec/BotPlutusInterface/Contract.hs
+++ b/test/Spec/BotPlutusInterface/Contract.hs
@@ -885,10 +885,10 @@ commandEqual :: Text -> Text -> Bool
 commandEqual "" "" = True
 commandEqual "" _ = False
 commandEqual _ "" = False
-commandEqual expected actual = maybe False (on commandEqual dropToSpace postExp) mRestAct
+commandEqual expected actual = maybe False (on commandEqual dropToSpace postExp) mPostAct
   where
     (preExp, postExp) = Text.breakOn "?" expected
-    mRestAct = Text.stripPrefix preExp actual
+    mPostAct = Text.stripPrefix preExp actual
     dropToSpace = Text.dropWhile (/= ' ')
 
 assertCommandCalled :: forall (w :: Type). MockContractState w -> Text -> Assertion


### PR DESCRIPTION
This interalises ada balancing, no longer relying on `cardano-cli transaction build`, and always building raw.
This means the Tx returned from `submitTx` or `balanceTx` is identical to the one submitted to the chain.
It also tweaks the balancing loop a bit to be more correct.
As such, `PreBalance` has been renamed to `Balance`

In order to handle the now changing txid of transaction as they are balanced, the tests were changed to now support a "?" in assertCommandHistory. Anywhere where a "?" is used in an expected command is seen as identical to up to the next space in the actual command.

See it as a regex `^[^ ]+(?= )`.
e.g.
```
this is an example actual command
```
As an actual command would compare equal to:
```
this is an example ? command
```