### PR TITLE
Fix signing keys and txs folder on remote

### DIFF
--- a/src/BotPlutusInterface/CardanoCLI.hs
+++ b/src/BotPlutusInterface/CardanoCLI.hs
@@ -7,7 +7,6 @@ module BotPlutusInterface.CardanoCLI (
   calculateMinFee,
   buildTx,
   signTx,
-  uploadFiles,
   validatorScriptFilePath,
   unsafeSerialiseAddress,
   policyScriptFilePath,
@@ -15,7 +14,7 @@ module BotPlutusInterface.CardanoCLI (
   queryTip,
 ) where
 
-import BotPlutusInterface.Effects (PABEffect, ShellArgs (..), callCommand, uploadDir)
+import BotPlutusInterface.Effects (PABEffect, ShellArgs (..), callCommand)
 import BotPlutusInterface.Files (
   DummyPrivKey (FromSKey, FromVKey),
   datumJsonFilePath,
@@ -92,19 +91,6 @@ import Plutus.V1.Ledger.Api (
 import Plutus.V1.Ledger.Api qualified as Plutus
 import PlutusTx.Builtins (fromBuiltin)
 import Prelude
-
--- | Upload script files to remote server
-uploadFiles ::
-  forall (w :: Type) (effs :: [Type -> Type]).
-  Member (PABEffect w) effs =>
-  PABConfig ->
-  Eff effs ()
-uploadFiles pabConf =
-  mapM_
-    (uploadDir @w)
-    [ pabConf.pcScriptFileDir
-    , pabConf.pcSigningKeyFileDir
-    ]
 
 -- | Getting information of the latest block
 queryTip ::

--- a/test/Spec/MockContract.hs
+++ b/test/Spec/MockContract.hs
@@ -279,6 +279,8 @@ runPABEffectPure initState req =
     go (CallCommand args) = mockCallCommand args
     go (CreateDirectoryIfMissing createParents filePath) =
       mockCreateDirectoryIfMissing createParents filePath
+    go (CreateDirectoryIfMissingCLI createParents filePath) =
+      mockCreateDirectoryIfMissing createParents filePath
     go (PrintLog logLevel msg) = mockPrintLog logLevel msg
     go (UpdateInstanceState msg) = mockUpdateInstanceState msg
     go (LogToContract msg) = mockLogToContract msg


### PR DESCRIPTION
When operating with a remote CLI, I noticed a few issues:
- Balancing transactions required the signing keys file to be on the remote machine, but they weren't written until submission
- The `txs` folder is always created on the local machine, whereas, if we're running remote, it needs to be on the remote machine
- Various files and directories are created in non-optimum places