### PR TITLE
Add jq and websocat, split up lib and examples build

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -76,4 +76,4 @@ jobs:
             dist-newstyle
           key: ${{ runner.os }}-cabal
       - name: Build the full ci derivation
-        run: make nix_build
+        run: make nix_build_lib && make nix_build_examples

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # In most cases you should execute Make after entering nix-shell.
 
 .PHONY: hoogle pab_servers_all pab_servers_all pab_db clean_db \
-	nix_build build test accept_pirs watch ghci readme_contents \
+	nix_build_lib nix_build_examples build test accept_pirs watch ghci readme_contents \
 	format lint requires_nix_shell 
 
 usage:
@@ -16,7 +16,8 @@ usage:
 	@echo
 	@echo "Available commands:"
 	@echo "  hoogle              -- Start local hoogle"
-	@echo "  nix_build           -- Run nix build -L on all targets"
+	@echo "  nix_build_lib       -- Run nix build -L on the library and tests"
+	@echo "  nix_build_examples  -- Run nix build -L on all examples"
 	@echo "  build               -- Run cabal v2-build"
 	@echo "  watch               -- Track files: bot-plutus-interface.cabal, src/* and run 'make build' on change"
 	@echo "  test                -- Run cabal v2-test"
@@ -45,8 +46,11 @@ ifdef FLAGS
 GHC_FLAGS = --ghc-options "$(FLAGS)"
 endif
 
-nix_build:
-	nix build -L .#check.x86_64-linux .#plutus-transfer:exe:plutus-transfer-pab .#plutus-game:exe:plutus-game-pab .#plutus-nft:exe:plutus-nft-pab
+nix_build_lib:
+	nix build -L .#check.x86_64-linux
+
+nix_build_examples:
+	nix build -L .#plutus-transfer:exe:plutus-transfer-pab .#plutus-game:exe:plutus-game-pab .#plutus-nft:exe:plutus-nft-pab
 
 build: requires_nix_shell
 	cabal v2-build $(GHC_FLAGS)

--- a/flake.nix
+++ b/flake.nix
@@ -68,7 +68,7 @@
             # We use the ones from Nixpkgs, since they are cached reliably.
             # Eventually we will probably want to build these with haskell.nix.
             nativeBuildInputs =
-              [ pkgs.cabal-install pkgs.hlint pkgs.haskellPackages.fourmolu ];
+              [ pkgs.cabal-install pkgs.hlint pkgs.haskellPackages.fourmolu pkgs.jq pkgs.websocat ];
 
             additional = ps: [
               ps.base-deriving-via


### PR DESCRIPTION
Following this, all examples build as part of CI (they did before, but now its more clear), and the nix shell has jq and websocat included.