### PR TITLE
Fix risk of getting `UnknownTxIns` during statistics saving

### DIFF
--- a/src/BotPlutusInterface/Contract.hs
+++ b/src/BotPlutusInterface/Contract.hs
@@ -301,8 +301,15 @@ writeBalancedTx contractEnv (Right tx) = do
 
     collectBudgetStats txId pabConf = do
       let path = Text.unpack (Files.txFilePath pabConf "signed" (Tx.txId tx))
-      b <- firstEitherT (Text.pack . show) $ newEitherT $ estimateBudget @w (Signed path)
-      void $ newEitherT (Right <$> saveBudget @w txId b)
+      txBudget <-
+        firstEitherT toBudgetSaveError $
+          newEitherT $ estimateBudget @w (Signed path)
+      void $ newEitherT (Right <$> saveBudget @w txId txBudget)
+
+    toBudgetSaveError =
+      Text.pack
+        . ("Failed to save Tx budgets statistics: " ++)
+        . show
 
 pkhToText :: Ledger.PubKey -> Text
 pkhToText = encodeByteString . fromBuiltin . Ledger.getPubKeyHash . Ledger.pubKeyHash


### PR DESCRIPTION
This PR fixes risk of getting `UnknownTxIns` that can happen during statistics collection, which is critical for current way `plutip` using `bpi`.

Problem:
* statistics collected by `bpi` include transaction execution budgets; to get those budgets estimation is performed, but it happens already after transaction is submitted, so depending on how fast transaction will be processed, there could be no required utxo's available anymore, which will lead to `UnknownTxIns` error

Changes:
* statistics calculation and saving moved to the point before transaction submission happens