### PR TITLE
Add option to collect logs inside ContractEnvironment.

### DIFF
--- a/examples/plutus-game/app/Main.hs
+++ b/examples/plutus-game/app/Main.hs
@@ -71,5 +71,6 @@ main = do
           , pcEnableTxEndpoint = True
           , pcMetadataDir = "./metadata"
           , pcCollectStats = False
+          , pcCollectLogs = False
           }
   BotPlutusInterface.runPAB @GameContracts pabConf

--- a/examples/plutus-nft/app/Main.hs
+++ b/examples/plutus-nft/app/Main.hs
@@ -67,5 +67,6 @@ main = do
           , pcEnableTxEndpoint = True
           , pcMetadataDir = "./metadata"
           , pcCollectStats = False
+          , pcCollectLogs = False
           }
   BotPlutusInterface.runPAB @MintNFTContracts pabConf

--- a/examples/plutus-transfer/app/Main.hs
+++ b/examples/plutus-transfer/app/Main.hs
@@ -70,5 +70,6 @@ main = do
           , pcEnableTxEndpoint = True
           , pcMetadataDir = "./metadata"
           , pcCollectStats = False
+          , pcCollectLogs = False
           }
   BotPlutusInterface.runPAB @TransferContracts pabConf

--- a/src/BotPlutusInterface/Server.hs
+++ b/src/BotPlutusInterface/Server.hs
@@ -273,6 +273,7 @@ handleContract pabConf state@(AppState st) contract = liftIO $ do
   contractInstanceID <- liftIO $ ContractInstanceId <$> UUID.nextRandom
   contractState <- newTVarIO (ContractState Active mempty)
   contractStats <- newTVarIO mempty
+  contractLogs <- newTVarIO mempty
 
   atomically $ modifyTVar st (Map.insert contractInstanceID (SomeContractState contractState))
 
@@ -282,6 +283,7 @@ handleContract pabConf state@(AppState st) contract = liftIO $ do
           , ceContractState = contractState
           , ceContractInstanceId = contractInstanceID
           , ceContractStats = contractStats
+          , ceContractLogs = contractLogs 
           }
   void $
     forkIO $ do

--- a/src/BotPlutusInterface/Types.hs
+++ b/src/BotPlutusInterface/Types.hs
@@ -22,6 +22,7 @@ module BotPlutusInterface.Types (
   SpendBudgets,
   MintBudgets,
   ContractStats (..),
+  LogsList (..),
   addBudget,
 ) where
 
@@ -55,6 +56,7 @@ import Plutus.PAB.Effects.Contract.Builtin (
   endpointsToSchemas,
  )
 import Prettyprinter (Pretty (pretty))
+import Prettyprinter qualified as PP
 import Servant.Client (BaseUrl (BaseUrl), Scheme (Http))
 import Wallet.Types (ContractInstanceId (..))
 import Prelude
@@ -86,6 +88,7 @@ data PABConfig = PABConfig
   , pcPort :: !Port
   , pcEnableTxEndpoint :: !Bool
   , pcCollectStats :: !Bool
+  , pcCollectLogs :: !Bool  
   }
   deriving stock (Show, Eq)
 
@@ -146,11 +149,22 @@ newtype ContractStats = ContractStats
 instance Show (TVar ContractStats) where
   show _ = "<ContractStats>"
 
+-- | List of string logs.
+newtype LogsList = LogsList
+  { getLogsList :: [(LogLevel, PP.Doc ())]
+  }
+  deriving stock (Show)
+  deriving newtype (Semigroup, Monoid)
+
+instance Show (TVar LogsList) where 
+  show _ = "<ContractLogs>"
+
 data ContractEnvironment w = ContractEnvironment
   { cePABConfig :: PABConfig
   , ceContractInstanceId :: ContractInstanceId
   , ceContractState :: TVar (ContractState w)
   , ceContractStats :: TVar ContractStats
+  , ceContractLogs  :: TVar LogsList
   }
   deriving stock (Show)
 
@@ -225,6 +239,7 @@ instance Default PABConfig where
       , pcPort = 9080
       , pcEnableTxEndpoint = False
       , pcCollectStats = False
+      , pcCollectLogs = False
       }
 
 data RawTx = RawTx

--- a/test/Spec/MockContract.hs
+++ b/test/Spec/MockContract.hs
@@ -244,6 +244,7 @@ instance Monoid w => Default (ContractEnvironment w) where
       , ceContractInstanceId = ContractInstanceId UUID.nil
       , ceContractState = unsafePerformIO $ newTVarIO def
       , ceContractStats = unsafePerformIO $ newTVarIO mempty
+      , ceContractLogs = unsafePerformIO $ newTVarIO mempty
       }
 
 instance Monoid w => Default (ContractState w) where


### PR DESCRIPTION
Adds additional interpretetion for PrintLog effect, that saves the log inside TVar in ContractEnviroment.
This is turned on/off by flag in PABConfig.

For use in plutip.