### PR TITLE
Pretty print test results

### DIFF
--- a/bot-plutus-interface.cabal
+++ b/bot-plutus-interface.cabal
@@ -215,6 +215,7 @@ test-suite bot-plutus-interface-test
     , plutus-pab
     , plutus-tx
     , plutus-tx-plugin
+    , pretty-diff
     , prettyprinter
     , QuickCheck
     , quickcheck-instances

--- a/test/Spec/BotPlutusInterface/Contract.hs
+++ b/test/Spec/BotPlutusInterface/Contract.hs
@@ -45,6 +45,11 @@ import Plutus.Contract (
  )
 import PlutusTx qualified
 import PlutusTx.Builtins (fromBuiltin)
+import Pretty.Diff (
+  MultilineContext (FullContext),
+  Wrapping (Wrap),
+ )
+import Pretty.Diff qualified as Diff
 import Spec.MockContract (
   MockContractState (..),
   addr1,
@@ -898,7 +903,16 @@ assertCommandHistory state =
 assertCommandEqual :: String -> Text -> Text -> Assertion
 assertCommandEqual err expected actual
   | commandEqual expected actual = return ()
-  | otherwise = assertFailure $ err ++ "\nExpected:\n" ++ show expected ++ "\nGot:\n" ++ show actual
+  | otherwise =
+    assertFailure $
+      err ++ "\n" ++ prettyPrintDiff expected actual
+
+prettyPrintDiff :: Text -> Text -> String
+prettyPrintDiff expected actual =
+  "\nExpected:\n"
+    ++ Text.unpack (Diff.above (Wrap 80) FullContext (Text.replace "\n" " " expected) actual)
+    ++ "\nGot:\n"
+    ++ Text.unpack (Diff.below (Wrap 80) FullContext (Text.replace "\n" " " expected) actual)
 
 {- | Checks if a command matches an expected command pattern
  Where a command pattern may use new lines in place of spaces, and use the wildcard `?` to match up to the next space


### PR DESCRIPTION
CLI commands are pretty long, and can be hard to find the differences, so I added some pretty diff there.
Example result:
```
    Send ada to address without change:                            FAIL (0.09s)
      test/Spec/BotPlutusInterface/Contract.hs:907:
      command at index 8 was incorrect:

      Expected:
                                          ▼ ▼▼▼▼▼
      cardano-cli transaction build-raw --babbage-era --tx-in e406b0cf676fc2b1a9edb061
      7f259ad025c20ea6f0333820aa7cef1bfe7302e5#0 --tx-out addr1vyxk54m7j3q6mrkevcunryr
      wf4p7e68c93cjk8gzxkhlkpsjpczl2+1000 --required-signer ./signing-keys/signing-key
      -cb9358529df4729c3246a2a033cb9821abbfd16de4888005904abc41.skey --fee 200 --proto
                                                          ▼
      col-params-file ./protocol.json --out-file ./txs/tx-?.raw
      Got:
      cardano-cli transaction build-raw --alonzo-era --tx-in e406b0cf676fc2b1a9edb0617
                                           ▲▲▲▲▲
      f259ad025c20ea6f0333820aa7cef1bfe7302e5#0 --tx-out addr1vyxk54m7j3q6mrkevcunryrw
      f4p7e68c93cjk8gzxkhlkpsjpczl2+1000 --required-signer ./signing-keys/signing-key-
      cb9358529df4729c3246a2a033cb9821abbfd16de4888005904abc41.skey --fee 200 --protoc
      ol-params-file ./protocol.json --out-file ./txs/tx-4862b799cba361cb2df20a66daf4d
                                                         ▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲
      d04190cbd1cb73e4b9562a5e891493345e5.raw
      ▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲
```