### PR TITLE
Fix fetching of protocol paramters if they are not specified in confi…

### DIFF
--- a/src/PlutusConfig/Cardano/Api/Shelley.hs
+++ b/src/PlutusConfig/Cardano/Api/Shelley.hs
@@ -20,6 +20,7 @@ import Config.Schema (
   naturalSpec,
   sectionsSpec,
  )
+import Control.Exception (IOException, catch)
 import Data.Aeson qualified as JSON
 import Data.ByteString.Lazy qualified as LazyByteString
 import Data.Default (def)
@@ -276,7 +277,7 @@ instance HasSpec ProtocolParameters where
     pure ProtocolParameters {..}
 
 readProtocolParametersJSON :: FilePath -> IO (Either String ProtocolParameters)
-readProtocolParametersJSON fn = JSON.eitherDecode <$> LazyByteString.readFile fn
+readProtocolParametersJSON fn = (JSON.eitherDecode <$> LazyByteString.readFile fn) `catch` (\(e :: IOException) -> pure $ Left (show e))
 
 writeProtocolParametersJSON :: FilePath -> ProtocolParameters -> IO ()
 writeProtocolParametersJSON fn params =


### PR DESCRIPTION
…g and if file is not present

Previously we would only fetch the file if JSON.decode returned a Left, however if the file is not present an IOError
will be thrown and the code to fetch the file through the CLI was never being executed

Change-type: patch
Signed-off-by: Giovanni Garufi <giovanni@mlabs.city>