### PR TITLE
Fix chain index query filtering

### DIFF
--- a/src/BotPlutusInterface/Balance.hs
+++ b/src/BotPlutusInterface/Balance.hs
@@ -13,9 +13,10 @@ module BotPlutusInterface.Balance (
 
 import BotPlutusInterface.BodyBuilder qualified as BodyBuilder
 import BotPlutusInterface.CardanoCLI qualified as CardanoCLI
-import BotPlutusInterface.CardanoNode.Effects (NodeQuery (UtxosAt))
+import BotPlutusInterface.CardanoNode.Effects (NodeQuery (UtxosAt, UtxosAtExcluding))
 import BotPlutusInterface.CoinSelection (selectTxIns)
-import BotPlutusInterface.Collateral (removeCollateralFromMap)
+
+-- import BotPlutusInterface.Collateral (removeCollateralFromMap)
 import BotPlutusInterface.Effects (
   PABEffect,
   createDirectoryIfMissingCLI,
@@ -84,6 +85,8 @@ import Plutus.V1.Ledger.Api (
 import Ledger.Constraints.OffChain qualified as Constraints
 import Prettyprinter (pretty, viaShow, (<+>))
 import Prelude
+
+-- import BotPlutusInterface.Collateral (removeCollateralFromMap)
 
 -- Config for balancing a `Tx`.
 data BalanceConfig = BalanceConfig
@@ -247,8 +250,14 @@ utxosAndCollateralAtAddress ::
   Eff effs (Either Text (Map TxOutRef Tx.ChainIndexTxOut, Maybe CollateralUtxo))
 utxosAndCollateralAtAddress balanceCfg _pabConf changeAddr =
   runEitherT $ do
-    utxos <- firstEitherT (Text.pack . show) $ newEitherT $ queryNode @w (UtxosAt changeAddr)
     inMemCollateral <- lift $ getInMemCollateral @w
+    let nodeQuery =
+          maybe
+            (UtxosAt changeAddr)
+            (UtxosAtExcluding changeAddr . Set.singleton . collateralTxOutRef)
+            inMemCollateral
+
+    utxos <- firstEitherT (Text.pack . show) $ newEitherT $ queryNode @w nodeQuery
 
     -- check if `bcHasScripts` is true, if this is the case then we search of
     -- collateral UTxO in the environment, if such collateral is not present we throw Error.
@@ -259,9 +268,9 @@ utxosAndCollateralAtAddress balanceCfg _pabConf changeAddr =
               "The given transaction uses script, but there's no collateral provided."
                 <> "This usually means that, we failed to create Tx and update our ContractEnvironment."
           )
-          (const $ pure (removeCollateralFromMap inMemCollateral utxos, inMemCollateral))
+          (const $ pure (utxos, inMemCollateral))
           inMemCollateral
-      else pure (removeCollateralFromMap inMemCollateral utxos, Nothing)
+      else pure (utxos, Nothing)
 
 hasChangeUTxO :: Address -> Tx -> Bool
 hasChangeUTxO changeAddr tx =

--- a/src/BotPlutusInterface/Balance.hs
+++ b/src/BotPlutusInterface/Balance.hs
@@ -16,7 +16,6 @@ import BotPlutusInterface.CardanoCLI qualified as CardanoCLI
 import BotPlutusInterface.CardanoNode.Effects (NodeQuery (UtxosAt, UtxosAtExcluding))
 import BotPlutusInterface.CoinSelection (selectTxIns)
 
--- import BotPlutusInterface.Collateral (removeCollateralFromMap)
 import BotPlutusInterface.Effects (
   PABEffect,
   createDirectoryIfMissingCLI,
@@ -85,8 +84,6 @@ import Plutus.V1.Ledger.Api (
 import Ledger.Constraints.OffChain qualified as Constraints
 import Prettyprinter (pretty, viaShow, (<+>))
 import Prelude
-
--- import BotPlutusInterface.Collateral (removeCollateralFromMap)
 
 -- Config for balancing a `Tx`.
 data BalanceConfig = BalanceConfig

--- a/src/BotPlutusInterface/CardanoNode/Effects.hs
+++ b/src/BotPlutusInterface/CardanoNode/Effects.hs
@@ -30,7 +30,7 @@ import BotPlutusInterface.CardanoAPI (
   fromCardanoTxOut,
  )
 
-import BotPlutusInterface.Types (PABConfig)
+import BotPlutusInterface.Types (PABConfig, cePABConfig)
 import Cardano.Api (LocalNodeConnectInfo (..))
 import Cardano.Api qualified as CApi
 import Cardano.Api.Shelley qualified as CApi.S
@@ -41,9 +41,10 @@ import Control.Monad.Trans.Class (lift)
 import Control.Monad.Trans.Either (firstEitherT, hoistEither, newEitherT, runEitherT)
 import Data.Map (Map)
 import Data.Map qualified as Map
+import Data.Set (Set)
 import Data.Set qualified as Set
 import Ledger.Address (Address)
-import Ledger.Tx (ChainIndexTxOut (..))
+import Ledger.Tx (ChainIndexTxOut (..), TxOutRef)
 import Ledger.Tx.CardanoAPI qualified as TxApi
 import Plutus.V2.Ledger.Tx qualified as V2
 import Prelude
@@ -54,6 +55,9 @@ import Prelude
 data NodeQuery a where
   -- | 'UtxosAt' queries local node to get all the utxos at particular address.
   UtxosAt :: Address -> NodeQuery (Either NodeQueryError (Map V2.TxOutRef ChainIndexTxOut))
+  -- | 'UtxosAt' queries local node to get all the utxos at particular address.
+  -- Does not return collateral UTxO created by BPI.
+  UtxosAtExcluding :: Address -> Set TxOutRef -> NodeQuery (Either NodeQueryError (Map V2.TxOutRef ChainIndexTxOut))
   -- | 'PParams' queries local node to get it's 'ProtocolParameters'.
   PParams :: NodeQuery (Either NodeQueryError CApi.S.ProtocolParameters)
 
@@ -78,6 +82,9 @@ handleNodeQuery =
   interpret $ \case
     UtxosAt addr -> handleUtxosAt addr
     PParams -> queryBabbageEra CApi.QueryProtocolParameters
+    UtxosAtExcluding addr excluded ->
+      let filterOuts = Map.filterWithKey (\oref _ -> not $ oref `Set.member` excluded)
+       in fmap filterOuts <$> handleUtxosAt addr
 
 handleUtxosAt ::
   forall effs.

--- a/src/BotPlutusInterface/CardanoNode/Effects.hs
+++ b/src/BotPlutusInterface/CardanoNode/Effects.hs
@@ -55,7 +55,7 @@ import Prelude
 data NodeQuery a where
   -- | 'UtxosAt' queries local node to get all the utxos at particular address.
   UtxosAt :: Address -> NodeQuery (Either NodeQueryError (Map V2.TxOutRef ChainIndexTxOut))
-  -- | 'UtxosAt' queries local node to get all the utxos at particular address.
+  -- | 'UtxosAtExcluding' queries local node to get all the utxos at particular address
   -- excluding `TxOutRefs`'s specified in `Set`.
   UtxosAtExcluding :: Address -> Set TxOutRef -> NodeQuery (Either NodeQueryError (Map V2.TxOutRef ChainIndexTxOut))
   -- | 'PParams' queries local node to get it's 'ProtocolParameters'.

--- a/src/BotPlutusInterface/CardanoNode/Effects.hs
+++ b/src/BotPlutusInterface/CardanoNode/Effects.hs
@@ -30,7 +30,7 @@ import BotPlutusInterface.CardanoAPI (
   fromCardanoTxOut,
  )
 
-import BotPlutusInterface.Types (PABConfig, cePABConfig)
+import BotPlutusInterface.Types (PABConfig)
 import Cardano.Api (LocalNodeConnectInfo (..))
 import Cardano.Api qualified as CApi
 import Cardano.Api.Shelley qualified as CApi.S
@@ -56,7 +56,7 @@ data NodeQuery a where
   -- | 'UtxosAt' queries local node to get all the utxos at particular address.
   UtxosAt :: Address -> NodeQuery (Either NodeQueryError (Map V2.TxOutRef ChainIndexTxOut))
   -- | 'UtxosAt' queries local node to get all the utxos at particular address.
-  -- Does not return collateral UTxO created by BPI.
+  -- excluding `TxOutRefs`'s specified in `Set`.
   UtxosAtExcluding :: Address -> Set TxOutRef -> NodeQuery (Either NodeQueryError (Map V2.TxOutRef ChainIndexTxOut))
   -- | 'PParams' queries local node to get it's 'ProtocolParameters'.
   PParams :: NodeQuery (Either NodeQueryError CApi.S.ProtocolParameters)

--- a/src/BotPlutusInterface/ChainIndex.hs
+++ b/src/BotPlutusInterface/ChainIndex.hs
@@ -70,7 +70,7 @@ handleChainIndexReq contractEnv@ContractEnvironment {cePABConfig} = \case
         contractEnv
         (ChainIndexClient.getUtxoSetAtAddress (UtxoAtAddressRequest (Just page) credential))
   UtxoSetWithCurrency page assetClass ->
-    UtxoSetAtResponse
+    UtxoSetWithCurrencyResponse
       <$> chainIndexUtxoQuery
         contractEnv
         (ChainIndexClient.getUtxoSetWithCurrency (UtxoWithCurrencyRequest (Just page) assetClass))

--- a/src/BotPlutusInterface/ChainIndex.hs
+++ b/src/BotPlutusInterface/ChainIndex.hs
@@ -36,52 +36,53 @@ import Servant.Client (
 import Prelude
 
 handleChainIndexReq :: forall (w :: Type). ContractEnvironment w -> ChainIndexQuery -> IO ChainIndexResponse
-handleChainIndexReq contractEnv@ContractEnvironment {cePABConfig} = \case
-  DatumFromHash datumHash ->
-    DatumHashResponse <$> chainIndexQueryOne cePABConfig (ChainIndexClient.getDatum datumHash)
-  ValidatorFromHash validatorHash ->
-    ValidatorHashResponse <$> chainIndexQueryOne cePABConfig (ChainIndexClient.getValidator validatorHash)
-  MintingPolicyFromHash mintingPolicyHash ->
-    MintingPolicyHashResponse
-      <$> chainIndexQueryOne cePABConfig (ChainIndexClient.getMintingPolicy mintingPolicyHash)
-  StakeValidatorFromHash stakeValidatorHash ->
-    StakeValidatorHashResponse
-      <$> chainIndexQueryOne cePABConfig (ChainIndexClient.getStakeValidator stakeValidatorHash)
-  RedeemerFromHash _ ->
-    pure $ RedeemerHashResponse Nothing
-  -- RedeemerFromHash redeemerHash ->
-  --   pure $ RedeemerHashResponse (Maybe Redeemer)
-  TxOutFromRef txOutRef ->
-    TxOutRefResponse <$> chainIndexQueryOne cePABConfig (ChainIndexClient.getTxOut txOutRef)
-  UnspentTxOutFromRef txOutRef ->
-    UnspentTxOutResponse <$> chainIndexQueryOne cePABConfig (ChainIndexClient.getUnspentTxOut txOutRef)
-  UnspentTxOutSetAtAddress page credential ->
-    UnspentTxOutsAtResponse
-      <$> chainIndexQueryMany
-        cePABConfig
-        (ChainIndexClient.getUnspentTxOutsAtAddress (QueryAtAddressRequest (Just page) credential))
-  TxFromTxId txId ->
-    TxIdResponse <$> chainIndexQueryOne cePABConfig (ChainIndexClient.getTx txId)
-  UtxoSetMembership txOutRef ->
-    UtxoSetMembershipResponse <$> chainIndexQueryMany cePABConfig (ChainIndexClient.getIsUtxo txOutRef)
-  UtxoSetAtAddress page credential ->
-    UtxoSetAtResponse
-      <$> chainIndexUtxoQuery
-        contractEnv
-        (ChainIndexClient.getUtxoSetAtAddress (UtxoAtAddressRequest (Just page) credential))
-  UtxoSetWithCurrency page assetClass ->
-    UtxoSetWithCurrencyResponse
-      <$> chainIndexUtxoQuery
-        contractEnv
-        (ChainIndexClient.getUtxoSetWithCurrency (UtxoWithCurrencyRequest (Just page) assetClass))
-  GetTip ->
-    GetTipResponse <$> chainIndexQueryMany cePABConfig ChainIndexClient.getTip
-  TxsFromTxIds txIds -> TxIdsResponse <$> chainIndexQueryMany cePABConfig (ChainIndexClient.getTxs txIds)
-  TxoSetAtAddress page credential ->
-    TxoSetAtResponse
-      <$> chainIndexTxoQuery
-        contractEnv
-        (ChainIndexClient.getTxoSetAtAddress (TxoAtAddressRequest (Just page) credential))
+handleChainIndexReq contractEnv@ContractEnvironment {cePABConfig} =
+  \case
+    DatumFromHash datumHash ->
+      DatumHashResponse <$> chainIndexQueryOne cePABConfig (ChainIndexClient.getDatum datumHash)
+    ValidatorFromHash validatorHash ->
+      ValidatorHashResponse <$> chainIndexQueryOne cePABConfig (ChainIndexClient.getValidator validatorHash)
+    MintingPolicyFromHash mintingPolicyHash ->
+      MintingPolicyHashResponse
+        <$> chainIndexQueryOne cePABConfig (ChainIndexClient.getMintingPolicy mintingPolicyHash)
+    StakeValidatorFromHash stakeValidatorHash ->
+      StakeValidatorHashResponse
+        <$> chainIndexQueryOne cePABConfig (ChainIndexClient.getStakeValidator stakeValidatorHash)
+    RedeemerFromHash _ ->
+      pure $ RedeemerHashResponse Nothing
+    -- RedeemerFromHash redeemerHash ->
+    --   pure $ RedeemerHashResponse (Maybe Redeemer)
+    TxOutFromRef txOutRef ->
+      TxOutRefResponse <$> chainIndexQueryOne cePABConfig (ChainIndexClient.getTxOut txOutRef)
+    UnspentTxOutFromRef txOutRef ->
+      UnspentTxOutResponse <$> chainIndexQueryOne cePABConfig (ChainIndexClient.getUnspentTxOut txOutRef)
+    UnspentTxOutSetAtAddress page credential ->
+      UnspentTxOutsAtResponse
+        <$> chainIndexQueryMany
+          cePABConfig
+          (ChainIndexClient.getUnspentTxOutsAtAddress (QueryAtAddressRequest (Just page) credential))
+    TxFromTxId txId ->
+      TxIdResponse <$> chainIndexQueryOne cePABConfig (ChainIndexClient.getTx txId)
+    UtxoSetMembership txOutRef ->
+      UtxoSetMembershipResponse <$> chainIndexQueryMany cePABConfig (ChainIndexClient.getIsUtxo txOutRef)
+    UtxoSetAtAddress page credential ->
+      UtxoSetAtResponse
+        <$> chainIndexUtxoQuery
+          contractEnv
+          (ChainIndexClient.getUtxoSetAtAddress (UtxoAtAddressRequest (Just page) credential))
+    UtxoSetWithCurrency page assetClass ->
+      UtxoSetWithCurrencyResponse
+        <$> chainIndexUtxoQuery
+          contractEnv
+          (ChainIndexClient.getUtxoSetWithCurrency (UtxoWithCurrencyRequest (Just page) assetClass))
+    GetTip ->
+      GetTipResponse <$> chainIndexQueryMany cePABConfig ChainIndexClient.getTip
+    TxsFromTxIds txIds -> TxIdsResponse <$> chainIndexQueryMany cePABConfig (ChainIndexClient.getTxs txIds)
+    TxoSetAtAddress page credential ->
+      TxoSetAtResponse
+        <$> chainIndexTxoQuery
+          contractEnv
+          (ChainIndexClient.getTxoSetAtAddress (TxoAtAddressRequest (Just page) credential))
 
 chainIndexQuery' :: forall (a :: Type). PABConfig -> ClientM a -> IO (Either ClientError a)
 chainIndexQuery' pabConf endpoint = do

--- a/src/BotPlutusInterface/Collateral.hs
+++ b/src/BotPlutusInterface/Collateral.hs
@@ -2,7 +2,7 @@ module BotPlutusInterface.Collateral (
   getInMemCollateral,
   setInMemCollateral,
   mkCollateralTx,
-  withColalteralHandling,
+  withCollateralHandling,
 ) where
 
 import BotPlutusInterface.Types (
@@ -57,13 +57,13 @@ mkCollateralTx pabConf = Constraints.mkTx @Void mempty txc
     txc = Constraints.mustPayToPubKey (PaymentPubKeyHash $ pcOwnPubKeyHash pabConf) (collateralValue pabConf)
 
 -- | Middleware to run `chain-index` queries and filter out collateral output from response.
-withColalteralHandling ::
+withCollateralHandling ::
   Monad m =>
   Maybe CollateralUtxo ->
   (ChainIndexQuery -> m ChainIndexResponse) ->
   ChainIndexQuery ->
   m ChainIndexResponse
-withColalteralHandling mCollateral runChainIndexQuery = \query -> do
+withCollateralHandling mCollateral runChainIndexQuery = \query -> do
   response <-
     adjustChainIndexResponse mCollateral query
       <$> runChainIndexQuery query

--- a/src/BotPlutusInterface/Effects.hs
+++ b/src/BotPlutusInterface/Effects.hs
@@ -37,7 +37,7 @@ module BotPlutusInterface.Effects (
 
 import BotPlutusInterface.CardanoNode.Effects (NodeQuery, runNodeQuery)
 import BotPlutusInterface.ChainIndex (handleChainIndexReq)
-import BotPlutusInterface.Collateral (adjustChainIndexResponse)
+import BotPlutusInterface.Collateral (withColalteralHandling)
 import BotPlutusInterface.Collateral qualified as Collateral
 import BotPlutusInterface.ExBudget qualified as ExBudget
 import BotPlutusInterface.TimeSlot qualified as TimeSlot
@@ -69,7 +69,7 @@ import Cardano.Prelude (maybeToEither)
 import Control.Concurrent qualified as Concurrent
 import Control.Concurrent.STM (TVar, atomically, modifyTVar, modifyTVar')
 import Control.Lens ((^.))
-import Control.Monad (unless, void, when)
+import Control.Monad (void, when)
 import Control.Monad.Freer (Eff, LastMember, Member, interpretM, reinterpret, send, subsume, type (~>))
 import Control.Monad.Freer.Extras (LogMsg (LMessage))
 import Control.Monad.Freer.Extras qualified as Freer
@@ -88,7 +88,7 @@ import Ledger qualified
 import Ledger.Ada qualified as Ada
 import Ledger.Tx.CardanoAPI qualified as TxApi
 import Ledger.Validation (Coin (Coin))
-import Plutus.Contract.Effects (ChainIndexQuery, ChainIndexResponse, PABReq (ChainIndexQueryReq), PABResp (ChainIndexQueryResp), matches)
+import Plutus.Contract.Effects (ChainIndexQuery, ChainIndexResponse)
 import Plutus.PAB.Core.ContractInstance.STM (Activity)
 import PlutusTx.Builtins.Internal (BuiltinByteString (BuiltinByteString))
 import Prettyprinter (Pretty (pretty), defaultLayoutOptions, layoutPretty)
@@ -196,11 +196,10 @@ handlePABEffect contractEnv =
               void $ readProcess "scp" ["-r", Text.unpack dir, Text.unpack $ ipAddr <> ":$HOME"] ""
         QueryChainIndex query -> do
           collateralUtxo <- Collateral.getInMemCollateral contractEnv
-          response <-
-            adjustChainIndexResponse collateralUtxo query
-              <$> handleChainIndexReq contractEnv query
-          ensureMatches query response
-          pure response
+          withColalteralHandling
+            collateralUtxo
+            (handleChainIndexReq contractEnv)
+            query
         QueryNode query -> runNodeQuery contractEnv.cePABConfig (send query)
         EstimateBudget txPath ->
           ExBudget.estimateBudget contractEnv.cePABConfig txPath
@@ -215,15 +214,6 @@ handlePABEffect contractEnv =
         SetInMemCollateral c -> Collateral.setInMemCollateral contractEnv c
         MinUtxo utxo -> return $ calcMinUtxo contractEnv.cePABConfig utxo
     )
-  where
-    ensureMatches query result =
-      unless (matches (ChainIndexQueryReq query) (ChainIndexQueryResp result)) $
-        error $
-          mconcat
-            [ "Chain-index request doesn't match response."
-            , "\nRequest: " ++ show query
-            , "\nResponse:" ++ show result
-            ]
 
 printLog' :: LogLevel -> LogLine -> IO ()
 printLog' logLevelSetting logLine =

--- a/src/BotPlutusInterface/Effects.hs
+++ b/src/BotPlutusInterface/Effects.hs
@@ -37,7 +37,7 @@ module BotPlutusInterface.Effects (
 
 import BotPlutusInterface.CardanoNode.Effects (NodeQuery, runNodeQuery)
 import BotPlutusInterface.ChainIndex (handleChainIndexReq)
-import BotPlutusInterface.Collateral (withColalteralHandling)
+import BotPlutusInterface.Collateral (withCollateralHandling)
 import BotPlutusInterface.Collateral qualified as Collateral
 import BotPlutusInterface.ExBudget qualified as ExBudget
 import BotPlutusInterface.TimeSlot qualified as TimeSlot
@@ -196,7 +196,7 @@ handlePABEffect contractEnv =
               void $ readProcess "scp" ["-r", Text.unpack dir, Text.unpack $ ipAddr <> ":$HOME"] ""
         QueryChainIndex query -> do
           collateralUtxo <- Collateral.getInMemCollateral contractEnv
-          withColalteralHandling
+          withCollateralHandling
             collateralUtxo
             (handleChainIndexReq contractEnv)
             query

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -3,6 +3,7 @@ module Main (main) where
 import Spec.BotPlutusInterface.AdjustUnbalanced qualified
 import Spec.BotPlutusInterface.Balance qualified
 import Spec.BotPlutusInterface.CoinSelection qualified
+import Spec.BotPlutusInterface.Collateral qualified
 import Spec.BotPlutusInterface.Contract qualified
 import Spec.BotPlutusInterface.ContractStats qualified
 import Spec.BotPlutusInterface.Server qualified
@@ -30,4 +31,5 @@ tests =
     , Spec.BotPlutusInterface.ContractStats.tests
     , Spec.BotPlutusInterface.TxStatusChange.tests
     , Spec.BotPlutusInterface.AdjustUnbalanced.tests
+    , Spec.BotPlutusInterface.Collateral.tests
     ]

--- a/test/Spec/BotPlutusInterface/Collateral.hs
+++ b/test/Spec/BotPlutusInterface/Collateral.hs
@@ -79,7 +79,7 @@ tests =
         "Should create collateral utxo if not present in user's wallets"
         testTxCreatesCollateralCorrectly
     , testCase
-        "Should not return collateral utxo in chai-index responses"
+        "Should not return collateral utxo in chain-index responses"
         testCollateralFiltering
     ]
 
@@ -254,7 +254,7 @@ testCollateralFiltering = do
     (Left e, _) -> assertFailure $ "Contract execution failed: " <> show e
   where
     assertCollateralNotRetunredBy request txOutFromRef' =
-      assertBool (request <> " should not return Nothing for collateral UTxO") (isNothing txOutFromRef')
+      assertBool (request <> " should return Nothing for collateral UTxO") (isNothing txOutFromRef')
 
     assertNotFoundIn :: (Foldable t, Eq a) => String -> a -> t a -> Assertion
     assertNotFoundIn what collateralOref outs =

--- a/test/Spec/BotPlutusInterface/Collateral.hs
+++ b/test/Spec/BotPlutusInterface/Collateral.hs
@@ -230,10 +230,10 @@ testCollateralFiltering = do
       , st
       ) -> do
         assertCollateralInDistribution collateralOref (st ^. utxos)
-        assertCollateralNotRetunredBy
+        assertCollateralNotReturnedBy
           "txOutFromRef"
           txOutFromRef'
-        assertCollateralNotRetunredBy
+        assertCollateralNotReturnedBy
           "unspentTxOutFromRef"
           unspentTxOutFromRef'
         assertBool
@@ -253,7 +253,7 @@ testCollateralFiltering = do
           (Map.keys utxosAt')
     (Left e, _) -> assertFailure $ "Contract execution failed: " <> show e
   where
-    assertCollateralNotRetunredBy request txOutFromRef' =
+    assertCollateralNotReturnedBy request txOutFromRef' =
       assertBool (request <> " should return Nothing for collateral UTxO") (isNothing txOutFromRef')
 
     assertNotFoundIn :: (Foldable t, Eq a) => String -> a -> t a -> Assertion
@@ -262,8 +262,8 @@ testCollateralFiltering = do
 
     assertCollateralInDistribution :: TxOutRef -> [(TxOutRef, Ledger.Tx.ChainIndexTxOut)] -> Assertion
     assertCollateralInDistribution collateralOref utxs =
-      let colalteral = lookup collateralOref utxs
-       in if isJust colalteral
+      let collateral = lookup collateralOref utxs
+       in if isJust collateral
             then pure ()
             else
               assertFailure

--- a/test/Spec/BotPlutusInterface/Contract.hs
+++ b/test/Spec/BotPlutusInterface/Contract.hs
@@ -664,7 +664,7 @@ redeemFromValidator = do
         ( 1
         , [text|
           cardano-cli transaction build-raw --babbage-era
-          --tx-in ${collateralTxId}#0 -- FIXME: redeem: we shouldn't see collateral out here I think, as it not suppose to participate in balancing
+          --tx-in ${inTxId}#0
           --tx-in ${inTxId}#1
           --tx-in-script-file ./result-scripts/validator-${valHash'}.plutus
           --tx-in-datum-file ./result-scripts/datum-${datumHash'}.json
@@ -680,7 +680,7 @@ redeemFromValidator = do
         ( 13
         , [text|
           cardano-cli transaction build-raw --babbage-era
-          --tx-in ${collateralTxId}#0
+          --tx-in ${inTxId}#0
           --tx-in ${inTxId}#1
           --tx-in-script-file ./result-scripts/validator-${valHash'}.plutus
           --tx-in-datum-file ./result-scripts/datum-${datumHash'}.json
@@ -688,7 +688,7 @@ redeemFromValidator = do
           --tx-in-execution-units (500000,2000)
           --tx-in-collateral ${collateralTxId}#0
           --tx-out ${addr2}+857690
-          --tx-out ${addr1}+9143160
+          --tx-out ${addr1}+49143160
           --required-signer ./signing-keys/signing-key-${pkh1'}.skey
           --fee 400
           --protocol-params-file ./protocol.json --out-file ./txs/tx-?.raw

--- a/test/Spec/BotPlutusInterface/Contract.hs
+++ b/test/Spec/BotPlutusInterface/Contract.hs
@@ -664,7 +664,7 @@ redeemFromValidator = do
         ( 1
         , [text|
           cardano-cli transaction build-raw --babbage-era
-          --tx-in ${collateralTxId}#0
+          --tx-in ${collateralTxId}#0 -- FIXME: redeem: we shouldn't see collateral out here I think, as it not suppose to participate in balancing
           --tx-in ${inTxId}#1
           --tx-in-script-file ./result-scripts/validator-${valHash'}.plutus
           --tx-in-datum-file ./result-scripts/datum-${datumHash'}.json

--- a/test/Spec/MockContract.hs
+++ b/test/Spec/MockContract.hs
@@ -676,7 +676,7 @@ mockQueryChainIndex ciq = do
         UtxoSetAtResponse $
           UtxosResponse
             (state ^. tip)
-            ((pageOf pageQuery (Set.fromList (state ^. utxos ^.. traverse . _1))))
+            (pageOf pageQuery (Set.fromList (state ^. utxos ^.. traverse . _1)))
     TxsFromTxIds ids -> do
       -- TODO: Track some kind of state here, add tests to ensure this works correctly
       -- For now, empty txs

--- a/test/Spec/MockContract.hs
+++ b/test/Spec/MockContract.hs
@@ -59,7 +59,7 @@ import BotPlutusInterface.CardanoNode.Query (toQueryError)
 
 -- import BotPlutusInterface.Collateral (removeCollateralFromPage)
 
-import BotPlutusInterface.Collateral (withColalteralHandling)
+import BotPlutusInterface.Collateral (withCollateralHandling)
 import BotPlutusInterface.Contract (handleContract)
 import BotPlutusInterface.Effects (PABEffect (..), ShellArgs (..), calcMinUtxo)
 import BotPlutusInterface.Files qualified as Files
@@ -375,7 +375,7 @@ runPABEffectPure initState req =
     go (UploadDir dir) = mockUploadDir dir
     go (QueryChainIndex query) = do
       mCollateral <- _collateralUtxo <$> get @(MockContractState w)
-      withColalteralHandling
+      withCollateralHandling
         mCollateral
         mockQueryChainIndex
         query

--- a/test/Spec/MockContract.hs
+++ b/test/Spec/MockContract.hs
@@ -122,7 +122,7 @@ import Data.Kind (Type)
 import Data.List (isPrefixOf, sortOn)
 import Data.Map (Map)
 import Data.Map qualified as Map
-import Data.Maybe (fromMaybe)
+import Data.Maybe (fromMaybe, isJust)
 import Data.Row (Row)
 import Data.Set qualified as Set
 import Data.Text (Text)
@@ -156,7 +156,7 @@ import Ledger.Tx (
 import Ledger.Tx qualified as Tx
 import Ledger.Value qualified as Value
 import NeatInterpolation (text)
-import Plutus.ChainIndex.Api (QueryResponse (QueryResponse), UtxosResponse (..))
+import Plutus.ChainIndex.Api (IsUtxoResponse (IsUtxoResponse), QueryResponse (QueryResponse), UtxosResponse (..))
 import Plutus.ChainIndex.Tx (
   ChainIndexTx (..),
   ChainIndexTxOutputs (ValidTx),
@@ -665,8 +665,11 @@ mockQueryChainIndex = \case
             , _citxScripts = mempty
             , _citxCardanoTx = Nothing
             }
-  UtxoSetMembership _ ->
-    throwError @Text "UtxoSetMembership is unimplemented"
+  UtxoSetMembership oref -> do
+    state <- get @(MockContractState w)
+    pure $
+      UtxoSetMembershipResponse $
+        IsUtxoResponse (state ^. tip) (isJust $ lookup oref (state ^. utxos))
   UtxoSetAtAddress pageQuery _ -> do
     state <- get @(MockContractState w)
     pure $

--- a/test/Spec/MockContract.hs
+++ b/test/Spec/MockContract.hs
@@ -57,8 +57,6 @@ import BotPlutusInterface.CardanoCLI (unsafeSerialiseAddress)
 import BotPlutusInterface.CardanoNode.Effects (NodeQuery (PParams, UtxosAt, UtxosAtExcluding))
 import BotPlutusInterface.CardanoNode.Query (toQueryError)
 
--- import BotPlutusInterface.Collateral (removeCollateralFromPage)
-
 import BotPlutusInterface.Collateral (withCollateralHandling)
 import BotPlutusInterface.Contract (handleContract)
 import BotPlutusInterface.Effects (PABEffect (..), ShellArgs (..), calcMinUtxo)

--- a/test/Spec/MockContract.hs
+++ b/test/Spec/MockContract.hs
@@ -814,8 +814,8 @@ mockQueryNode = \case
     return $ Right $ Map.fromList (state ^. utxos)
   UtxosAtExcluding _addr excluded -> do
     state <- get @(MockContractState w)
-    let filterOuts = Map.filterWithKey (\oref _ -> not $ oref `Set.member` excluded)
-    return . Right . filterOuts $ Map.fromList (state ^. utxos)
+    let filterNotExcluded = filter (not . (`Set.member` excluded) . fst)
+    return . Right . Map.fromList . filterNotExcluded $ (state ^. utxos)
   PParams -> do
     state <- get @(MockContractState w)
     case pcProtocolParams $ cePABConfig $ _contractEnv state of

--- a/test/Spec/MockContract.hs
+++ b/test/Spec/MockContract.hs
@@ -677,7 +677,7 @@ mockQueryChainIndex = \case
   UtxoSetWithCurrency pageQuery _ -> do
     state <- get @(MockContractState w)
     pure $
-      UtxoSetAtResponse $
+      UtxoSetWithCurrencyResponse $
         UtxosResponse
           (state ^. tip)
           (pageOf pageQuery (Set.fromList (state ^. utxos ^.. traverse . _1)))


### PR DESCRIPTION
This PR:
* Adds handling of missing cases when collateral should not be returned by chain-index responses
* Adds node query effect like `UtxosAt ` but with filtering - `UtxosAtExcluding`
* Enables other collateral tests (they were not included to suite for some reason)
* Fixes some collateral-affected tests