### PR TITLE
 Support for addresses with staking keys [Plutip's #103].

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ cardano-cli query protocol-parameters --testnet-magic 42 --out-file protocol.jso
 ```
 
 5. Create a `signing-keys` folder under your projects root with the necessary signig key file(s).
-   The files should be named in the following format: `signing-key-PUBKEYHASH.skey`
+   The files should be named in the following format: `signing-key-PUBKEYHASHHEX.skey` and `verification-key-PUBKEYHASHHEX.vkey`
 
 Use the cardano-cli to find out the pub key hash for your key:
 

--- a/src/BotPlutusInterface/Files.hs
+++ b/src/BotPlutusInterface/Files.hs
@@ -59,7 +59,7 @@ import Data.ByteString.Lazy qualified as LazyByteString
 import Data.ByteString.Short qualified as ShortByteString
 import Data.Either.Combinators (mapLeft)
 import Data.Kind (Type)
-import Data.List (sortOn, unzip4)
+import Data.List (sortOn, unzip4, isPrefixOf)
 import Data.Map (Map)
 import Data.Map qualified as Map
 import Data.Maybe (catMaybes, mapMaybe)
@@ -218,8 +218,8 @@ readPrivateKeys pabConf = do
         ( \filename ->
             let fullPath = Text.unpack pabConf.pcSigningKeyFileDir </> filename
              in case takeExtension filename of
-                  ".vkey" -> Just <$> readVerificationKey @w fullPath
-                  ".skey" -> Just <$> readSigningKey @w fullPath
+                  ".vkey" -> if "verification-key" `isPrefixOf` filename then Just <$> readVerificationKey @w fullPath else pure Nothing
+                  ".skey" -> if "signing-key" `isPrefixOf` filename then Just <$> readSigningKey @w fullPath else pure Nothing
                   _ -> pure Nothing
         )
         files

--- a/src/BotPlutusInterface/Files.hs
+++ b/src/BotPlutusInterface/Files.hs
@@ -59,7 +59,7 @@ import Data.ByteString.Lazy qualified as LazyByteString
 import Data.ByteString.Short qualified as ShortByteString
 import Data.Either.Combinators (mapLeft)
 import Data.Kind (Type)
-import Data.List (sortOn, unzip4, isPrefixOf)
+import Data.List (isPrefixOf, sortOn, unzip4)
 import Data.Map (Map)
 import Data.Map qualified as Map
 import Data.Maybe (catMaybes, mapMaybe)

--- a/test/Spec/MockContract.hs
+++ b/test/Spec/MockContract.hs
@@ -250,7 +250,7 @@ toSigningKeyFile signingKeyFileDir sKey =
 
 toVerificationKeyFile :: FilePath -> VerificationKey PaymentKey -> (FilePath, MockFile)
 toVerificationKeyFile signingKeyFileDir vKey =
-  ( signingKeyFileDir ++ "/signing-key-" ++ show (Ledger.pubKeyHash (vkeyToPubKey vKey)) ++ ".vkey"
+  ( signingKeyFileDir ++ "/verification-key-" ++ show (Ledger.pubKeyHash (vkeyToPubKey vKey)) ++ ".vkey"
   , TextEnvelopeFile $ serialiseToTextEnvelope Nothing vKey
   )
 


### PR DESCRIPTION
 - Fixes collateral utxo being sent always to an enterprise address, ignoring `pcOwnStakePubKeyHash`.
 - In `readPrivateKeys` matches both on extension and on file name, allowing for stake keys to be saved into `signing-keys` directory together with payment keys and not being mixed up.

Aboves don't change any existing behavior of bpi. 
TODO: Use staking keys for signing Tx, needs newest plutus-apps