### PR TITLE
Adjusting collateral creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,3 +167,11 @@ The fake PAB consists of the following modules:
   - adding collaterals,
   - modifying tx outs to contain the minimum amount of lovelaces
   - balancing non ada outputs
+
+## Collateral handling
+
+Current version handles collateral under the hood.
+
+Before contract being executed, single transaction submitted to create collateral UTxO at "own" address. Default amount for collateral UTxO is 10 Ada. It also can be set via config.
+
+BPI identifies collateral UTxO by its value. If "own" address already has UTxO with amount set in config, this UTxO will be used as collateral. UTxO that was picked as collateral is stored in memory, so each time BPI will use same UTxO for collateral. Also, collateral is not returned among other UTxOs inside `Contract` monad, e.g. from eDSL functions like `utxosAt`. So it is safe to use such functions without the risk of consuming collateral by accident.

--- a/src/BotPlutusInterface/Contract.hs
+++ b/src/BotPlutusInterface/Contract.hs
@@ -43,6 +43,7 @@ import BotPlutusInterface.Types (
   TxFile (Signed),
   collateralValue,
   pcCollateralSize,
+  pcOwnPubKeyHash,
  )
 import Cardano.Api (
   AsType (..),
@@ -524,6 +525,7 @@ handleCollateral ::
   ContractEnvironment w ->
   Eff effs (Either WAPI.WalletAPIError ())
 handleCollateral cEnv = do
+  let ownPkh = pcOwnPubKeyHash $ cePABConfig cEnv
   result <- (fmap swapEither . runEitherT) $
     do
       let helperLog :: PP.Doc () -> ExceptT CollateralUtxo (Eff effs) ()
@@ -531,7 +533,7 @@ handleCollateral cEnv = do
 
       collateralNotInMem <-
         newEitherT $
-          maybeToLeft "Collateral UTxO not found in contract env."
+          maybeToLeft ("PKH: " <> pretty ownPkh <> ". Collateral UTxO not found in contract env.")
             <$> getInMemCollateral @w
 
       helperLog collateralNotInMem
@@ -539,22 +541,37 @@ handleCollateral cEnv = do
       collateralNotInWallet <- newEitherT $ swapEither <$> findCollateralAtOwnPKH cEnv
 
       helperLog
-        ("Collateral UTxO not found or failed to be found in wallet: " <> pretty collateralNotInWallet)
+        ( "PKH: " <> pretty ownPkh <> ". Collateral UTxO not found or failed to be found in wallet: "
+            <> pretty collateralNotInWallet
+        )
 
-      helperLog "Creating collateral UTxO."
+      helperLog ("PKH: " <> pretty ownPkh <> ". Creating collateral UTxO.")
 
       notCreatedCollateral <- newEitherT $ swapEither <$> makeCollateral @w cEnv
 
       helperLog
-        ("Failed to create collateral UTxO: " <> pretty notCreatedCollateral)
+        ( "PKH: " <> pretty ownPkh <> ". Failed to create collateral UTxO: "
+            <> pretty notCreatedCollateral
+        )
 
-      pure ("Failed to create collateral UTxO: " <> show notCreatedCollateral)
+      pure
+        ( "PKH: " <> show ownPkh <> ". Failed to create collateral UTxO: "
+            <> show notCreatedCollateral
+        )
 
   case result of
     Right collteralUtxo ->
       setInMemCollateral @w collteralUtxo
-        >> Right <$> printBpiLog @w (Debug [CollateralLog]) "successfully set the collateral utxo in env."
-    Left err -> pure $ Left $ WAPI.OtherError $ T.pack $ "Failed to make collateral: " <> show err
+        >> Right
+          <$> printBpiLog @w
+            (Debug [CollateralLog])
+            ("PKH: " <> pretty ownPkh <> ". Successfully set the collateral utxo in env.")
+    Left err ->
+      pure $
+        Left $
+          WAPI.OtherError $
+            T.pack $
+              "PKH: " <> show ownPkh <> ". Failed to make collateral: " <> show err
 
 {- | Create collateral UTxO by submitting Tx.
   Then try to find created UTxO at own PKH address.


### PR DESCRIPTION
With this PR BPI will try to create collateral _before_ any user contract is executed.
If creation fails - contract execution will be aborted.

This behavior should fix the following possible scenario: 

1. user calls `utxosAt` in the contract (first contract executed with BPI in current session)
2. gets 1st UTxO from the result of `utxosAt` and uses it as transaction input
3. submits unbalanced or balances transaction
4. transaction fails because UTxO used as input could be consumed during collateral creation, which happens during balancing