### PR TITLE
Segfault fix (removing RecordDotPreprocessor)

### DIFF
--- a/bot-plutus-interface.cabal
+++ b/bot-plutus-interface.cabal
@@ -27,7 +27,7 @@ common common-lang
     -Wall -Wcompat -Wincomplete-record-updates
     -Wincomplete-uni-patterns -Wredundant-constraints -fobject-code
     -fno-ignore-interface-pragmas -fno-omit-interface-pragmas
-    -fplugin=RecordDotPreprocessor -Werror
+    -Werror
 
   build-depends:
     , base

--- a/src/BotPlutusInterface.hs
+++ b/src/BotPlutusInterface.hs
@@ -15,4 +15,4 @@ runPAB pabConf = do
   putStrLn "Starting BotPlutusInterface server"
   state <- Server.initState
 
-  run pabConf.pcPort (Server.app @t pabConf state)
+  run (pcPort pabConf) (Server.app @t pabConf state)

--- a/src/BotPlutusInterface/Balance.hs
+++ b/src/BotPlutusInterface/Balance.hs
@@ -28,7 +28,7 @@ import BotPlutusInterface.Types (
   CollateralUtxo (collateralTxOutRef),
   LogLevel (Debug),
   LogType (TxBalancingLog),
-  PABConfig,
+  PABConfig (..),
   collateralTxOutRef,
  )
 import Cardano.Api (ExecutionUnitPrices (ExecutionUnitPrices))
@@ -182,7 +182,7 @@ balanceTxIO' balanceCfg pabConf ownPkh unbalancedTx =
       hoistEither $ addSignatories ownPkh privKeys requiredSigs fullyBalancedTx
   where
     changeAddr :: Address
-    changeAddr = Ledger.pubKeyHashAddress (Ledger.PaymentPubKeyHash ownPkh) pabConf.pcOwnStakePubKeyHash
+    changeAddr = Ledger.pubKeyHashAddress (Ledger.PaymentPubKeyHash ownPkh) (pcOwnStakePubKeyHash pabConf)
 
     balanceTxLoop ::
       Map TxOutRef TxOut ->
@@ -249,7 +249,7 @@ hasChangeUTxO changeAddr tx =
 getExecutionUnitPrices :: PABConfig -> ExecutionUnitPrices
 getExecutionUnitPrices pabConf =
   fromMaybe (ExecutionUnitPrices 0 0) $
-    pabConf.pcProtocolParams >>= protocolParamPrices
+    pcProtocolParams pabConf >>= protocolParamPrices
 
 getBudgetPrice :: ExecutionUnitPrices -> Ledger.ExBudget -> Integer
 getBudgetPrice (ExecutionUnitPrices cpuPrice memPrice) (Ledger.ExBudget cpuUsed memUsed) =

--- a/src/BotPlutusInterface/Balance.hs
+++ b/src/BotPlutusInterface/Balance.hs
@@ -451,7 +451,7 @@ modifyFirst p m (x : xs) = if p x then m (Just x) `consJust` xs else x : modifyF
 
 minus :: Value -> Value -> Value
 minus x y =
-  let negativeValues = map (\(c, t, a) -> (c, t, - a)) $ Value.flattenValue y
+  let negativeValues = map (\(c, t, a) -> (c, t, -a)) $ Value.flattenValue y
    in x <> mconcat (map unflattenValue negativeValues)
 
 unflattenValue :: (CurrencySymbol, TokenName, Integer) -> Value

--- a/src/BotPlutusInterface/CardanoCLI.hs
+++ b/src/BotPlutusInterface/CardanoCLI.hs
@@ -27,7 +27,7 @@ import BotPlutusInterface.Files (
  )
 import BotPlutusInterface.Types (
   MintBudgets,
-  PABConfig,
+  PABConfig (..),
   SpendBudgets,
   Tip,
   TxBudget,
@@ -112,7 +112,7 @@ utxosAt pabConf address =
       , cmdArgs =
           mconcat
             [ ["query", "utxo"]
-            , ["--address", unsafeSerialiseAddress pabConf.pcNetwork address]
+            , ["--address", unsafeSerialiseAddress (pcNetwork pabConf) address]
             , networkOpt pabConf
             ]
       , cmdOutParser =
@@ -141,7 +141,7 @@ calculateMinFee pabConf tx =
               , ["--tx-in-count", showText $ length $ txInputs tx]
               , ["--tx-out-count", showText $ length $ txOutputs tx]
               , ["--witness-count", showText $ length $ txSignatures tx]
-              , ["--protocol-params-file", pabConf.pcProtocolParamsFile]
+              , ["--protocol-params-file", pcProtocolParamsFile pabConf]
               , networkOpt pabConf
               ]
         , cmdOutParser = mapLeft Text.pack . parseOnly UtxoParser.feeParser . Text.pack
@@ -187,7 +187,7 @@ buildTx pabConf privKeys txBudget tx = do
           requiredSigners
         , ["--fee", showText . getLovelace . fromValue $ txFee tx]
         , mconcat
-            [ ["--protocol-params-file", pabConf.pcProtocolParamsFile]
+            [ ["--protocol-params-file", pcProtocolParamsFile pabConf]
             , ["--out-file", txFilePath pabConf "raw" (txId tx)]
             ]
         ]
@@ -343,7 +343,7 @@ txOutOpts pabConf datums =
             [ "--tx-out"
             , Text.intercalate
                 "+"
-                [ unsafeSerialiseAddress pabConf.pcNetwork txOutAddress
+                [ unsafeSerialiseAddress (pcNetwork pabConf) txOutAddress
                 , valueToCliArg txOutValue
                 ]
             ]
@@ -357,7 +357,7 @@ txOutOpts pabConf datums =
     )
 
 networkOpt :: PABConfig -> [Text]
-networkOpt pabConf = case pabConf.pcNetwork of
+networkOpt pabConf = case pcNetwork pabConf of
   Testnet (NetworkMagic t) -> ["--testnet-magic", showText t]
   Mainnet -> ["--mainnet"]
 

--- a/src/BotPlutusInterface/ChainIndex.hs
+++ b/src/BotPlutusInterface/ChainIndex.hs
@@ -7,7 +7,7 @@ module BotPlutusInterface.ChainIndex (
 import BotPlutusInterface.Collateral (removeCollateralFromPage)
 import BotPlutusInterface.Types (
   ContractEnvironment (ContractEnvironment, cePABConfig),
-  PABConfig,
+  PABConfig (..),
   readCollateralUtxo,
  )
 import Data.Kind (Type)
@@ -89,7 +89,7 @@ handleChainIndexReq contractEnv@ContractEnvironment {cePABConfig} =
 chainIndexQuery' :: forall (a :: Type). PABConfig -> ClientM a -> IO (Either ClientError a)
 chainIndexQuery' pabConf endpoint = do
   manager' <- newManager defaultManagerSettings {managerResponseTimeout = responseTimeoutNone}
-  runClientM endpoint $ mkClientEnv manager' pabConf.pcChainIndexUrl
+  runClientM endpoint $ mkClientEnv manager' $ pcChainIndexUrl pabConf
 
 chainIndexQueryMany :: forall (a :: Type). PABConfig -> ClientM a -> IO a
 chainIndexQueryMany pabConf endpoint =
@@ -113,7 +113,7 @@ chainIndexUtxoQuery contractEnv query = do
       removeCollateral (UtxosResponse tip page) = UtxosResponse tip (removeCollateralFromPage collateralUtxo page)
   removeCollateral
     <$> chainIndexQueryMany
-      contractEnv.cePABConfig
+      (cePABConfig contractEnv)
       query
 
 -- | Query for txo's and filter collateral txo from result.
@@ -124,5 +124,5 @@ chainIndexTxoQuery contractEnv query = do
       removeCollateral (TxosResponse page) = TxosResponse (removeCollateralFromPage collateralUtxo page)
   removeCollateral
     <$> chainIndexQueryMany
-      contractEnv.cePABConfig
+      (cePABConfig contractEnv)
       query

--- a/src/BotPlutusInterface/Effects.hs
+++ b/src/BotPlutusInterface/Effects.hs
@@ -41,13 +41,13 @@ import BotPlutusInterface.Types (
   CLILocation (..),
   CollateralUtxo,
   ContractEnvironment (..),
-  PABConfig (..),
   ContractState (ContractState),
   LogContext (BpiLog, ContractLog),
   LogLevel (..),
   LogLine (..),
   LogType (..),
   LogsList (LogsList),
+  PABConfig (..),
   TxBudget,
   TxFile,
   addBudget,
@@ -152,7 +152,7 @@ handlePABEffect contractEnv =
         PrintLog logCtx logLevel msg -> do
           let logLine = LogLine logCtx logLevel msg
           printLog' (pcLogLevel (cePABConfig contractEnv)) logLine
-          when (pcCollectLogs (cePABConfig contractEnv)) $ 
+          when (pcCollectLogs (cePABConfig contractEnv)) $
             collectLog (ceContractLogs contractEnv) logLine
         UpdateInstanceState s -> do
           atomically $

--- a/src/BotPlutusInterface/ExBudget.hs
+++ b/src/BotPlutusInterface/ExBudget.hs
@@ -59,7 +59,7 @@ estimateBudget pabConf txFile = do
         maybeToEither (BudgetEstimationError "Missing max units in parameters") $
           protocolParamMaxTxExUnits pparams
 
-      scaledBudget <- getScaledBudget maxUnits (pcBudgetMultiplier  pabConf) budget
+      scaledBudget <- getScaledBudget maxUnits (pcBudgetMultiplier pabConf) budget
 
       (spendingBudgets, policyBudgets) <- mkBudgetMaps scaledBudget body
 

--- a/src/BotPlutusInterface/ExBudget.hs
+++ b/src/BotPlutusInterface/ExBudget.hs
@@ -8,7 +8,7 @@ import BotPlutusInterface.QueryNode qualified as QueryNode
 import BotPlutusInterface.Types (
   BudgetEstimationError (..),
   MintBudgets,
-  PABConfig (pcNetwork),
+  PABConfig (..),
   SpendBudgets,
   TxBudget (TxBudget),
   TxFile (..),
@@ -54,12 +54,12 @@ estimateBudget pabConf txFile = do
       pparams <-
         maybeToEither
           (BudgetEstimationError "No protocol params found")
-          pabConf.pcProtocolParams
+          $ pcProtocolParams pabConf
       maxUnits <-
         maybeToEither (BudgetEstimationError "Missing max units in parameters") $
           protocolParamMaxTxExUnits pparams
 
-      scaledBudget <- getScaledBudget maxUnits pabConf.pcBudgetMultiplier budget
+      scaledBudget <- getScaledBudget maxUnits (pcBudgetMultiplier  pabConf) budget
 
       (spendingBudgets, policyBudgets) <- mkBudgetMaps scaledBudget body
 

--- a/src/BotPlutusInterface/Files.hs
+++ b/src/BotPlutusInterface/Files.hs
@@ -32,7 +32,7 @@ import BotPlutusInterface.Effects (
   writeFileJSON,
   writeFileTextEnvelope,
  )
-import BotPlutusInterface.Types (PABConfig)
+import BotPlutusInterface.Types (PABConfig (..))
 import Cardano.Api (
   AsType (AsPaymentKey, AsSigningKey, AsVerificationKey),
   FileError,
@@ -95,31 +95,31 @@ import Prelude
 policyScriptFilePath :: PABConfig -> CurrencySymbol -> Text
 policyScriptFilePath pabConf curSymbol =
   let c = encodeByteString $ fromBuiltin $ Value.unCurrencySymbol curSymbol
-   in pabConf.pcScriptFileDir <> "/policy-" <> c <> ".plutus"
+   in pcScriptFileDir pabConf <> "/policy-" <> c <> ".plutus"
 
 -- | Path and filename of a validator script
 validatorScriptFilePath :: PABConfig -> ValidatorHash -> Text
 validatorScriptFilePath pabConf (ValidatorHash valHash) =
   let h = encodeByteString $ fromBuiltin valHash
-   in pabConf.pcScriptFileDir <> "/validator-" <> h <> ".plutus"
+   in pcScriptFileDir pabConf <> "/validator-" <> h <> ".plutus"
 
 datumJsonFilePath :: PABConfig -> DatumHash -> Text
 datumJsonFilePath pabConf (DatumHash datumHash) =
   let h = encodeByteString $ fromBuiltin datumHash
-   in pabConf.pcScriptFileDir <> "/datum-" <> h <> ".json"
+   in pcScriptFileDir pabConf <> "/datum-" <> h <> ".json"
 
 redeemerJsonFilePath :: PABConfig -> RedeemerHash -> Text
 redeemerJsonFilePath pabConf (RedeemerHash redeemerHash) =
   let h = encodeByteString $ fromBuiltin redeemerHash
-   in pabConf.pcScriptFileDir <> "/redeemer-" <> h <> ".json"
+   in pcScriptFileDir pabConf <> "/redeemer-" <> h <> ".json"
 
 signingKeyFilePath :: PABConfig -> PubKeyHash -> Text
 signingKeyFilePath pabConf (PubKeyHash pubKeyHash) =
   let h = encodeByteString $ fromBuiltin pubKeyHash
-   in pabConf.pcSigningKeyFileDir <> "/signing-key-" <> h <> ".skey"
+   in pcSigningKeyFileDir pabConf <> "/signing-key-" <> h <> ".skey"
 
 txFilePath :: PABConfig -> Text -> Tx.TxId -> Text
-txFilePath pabConf ext txId = pabConf.pcTxFileDir <> "/" <> txFileName txId ext
+txFilePath pabConf ext txId = pcTxFileDir pabConf <> "/" <> txFileName txId ext
 
 txFileName :: Tx.TxId -> Text -> Text
 txFileName txId ext = "tx-" <> txIdToText txId <> "." <> ext
@@ -180,7 +180,7 @@ writeAll ::
   Tx ->
   Eff effs (Either (FileError ()) [Text])
 writeAll pabConf tx = do
-  createDirectoryIfMissing @w False (Text.unpack pabConf.pcScriptFileDir)
+  createDirectoryIfMissing @w False (Text.unpack $ pcScriptFileDir pabConf)
   -- TODO: Removed for now, as the main iohk branch doesn't support metadata yet
   -- createDirectoryIfMissing @w False (Text.unpack pabConf.pcMetadataDir)
 
@@ -210,13 +210,13 @@ readPrivateKeys ::
   PABConfig ->
   Eff effs (Either Text (Map PubKeyHash DummyPrivKey))
 readPrivateKeys pabConf = do
-  files <- listDirectory @w $ Text.unpack pabConf.pcSigningKeyFileDir
+  files <- listDirectory @w $ Text.unpack (pcSigningKeyFileDir pabConf)
 
   privKeys <-
     catMaybes
       <$> mapM
         ( \filename ->
-            let fullPath = Text.unpack pabConf.pcSigningKeyFileDir </> filename
+            let fullPath = Text.unpack (pcSigningKeyFileDir pabConf) </> filename
              in case takeExtension filename of
                   ".vkey" -> Just <$> readVerificationKey @w fullPath
                   ".skey" -> Just <$> readSigningKey @w fullPath

--- a/src/BotPlutusInterface/Server.hs
+++ b/src/BotPlutusInterface/Server.hs
@@ -203,19 +203,19 @@ handleContractActivityChange contractInstanceID prevState currentState =
   catMaybes [observableStateChange, activityChange]
   where
     activityChange =
-      if (csActivity <$> prevState) /= Just currentState.csActivity
-        then case currentState.csActivity of
+      if (csActivity <$> prevState) /= Just (csActivity currentState)
+        then case csActivity currentState of
           Done maybeError -> do
             Just $ InstanceUpdate contractInstanceID $ ContractFinished maybeError
           _ -> Nothing
         else Nothing
 
     observableStateChange =
-      if (toJSON . csObservableState <$> prevState) /= Just (toJSON currentState.csObservableState)
+      if (toJSON . csObservableState <$> prevState) /= Just (toJSON (csObservableState currentState))
         then
           Just $
             InstanceUpdate contractInstanceID $
-              NewObservableState (toJSON currentState.csObservableState)
+              NewObservableState (toJSON (csObservableState currentState))
         else Nothing
 
 -- | Broadcast a contract update to subscribers
@@ -299,9 +299,9 @@ handleContract pabConf state@(AppState st) contract = liftIO $ do
 rawTxHandler :: PABConfig -> TxIdCapture -> Handler RawTx
 rawTxHandler config (TxIdCapture txId) = do
   -- Check that endpoint is enabled
-  assert config.pcEnableTxEndpoint
+  assert (pcEnableTxEndpoint config)
   -- Absolute path to pcTxFileDir that is specified in the config
-  txFolderPath <- liftIO $ makeAbsolute (unpack config.pcTxFileDir)
+  txFolderPath <- liftIO $ makeAbsolute (unpack (pcTxFileDir config))
 
   -- Create full path
   let path :: FilePath

--- a/test/Spec/MockContract.hs
+++ b/test/Spec/MockContract.hs
@@ -465,7 +465,7 @@ mockQueryUtxo :: forall (w :: Type). Text -> MockContract w String
 mockQueryUtxo addr = do
   state <- get @(MockContractState w)
 
-  let network = (state ^. contractEnv).cePABConfig.pcNetwork
+  let network = pcNetwork (cePABConfig (state ^. contractEnv))
   pure $
     mockQueryUtxoOut $
       filter


### PR DESCRIPTION
This should fix the segfault with when typing `nix build` by removing record dot preproccessor. For motivation for why this is here, see https://github.com/mlabs-haskell/trustless-sidechain/pull/272; but otherwise this can be ignored.