### PR TITLE
Update hw-aeson

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -442,17 +442,17 @@
     "hw-aeson": {
       "flake": false,
       "locked": {
-        "lastModified": 1660113261,
-        "narHash": "sha256-v0SyVxeVBTtW1tuej4P+Kf4roO/rr2tBI7RthTlInbc=",
+        "lastModified": 1660218478,
+        "narHash": "sha256-t4QLmGf5ytzjS0ynn6xON61J+fvBF8vf/+zsBzmw/rM=",
         "owner": "haskell-works",
         "repo": "hw-aeson",
-        "rev": "b5ef03a7d7443fcd6217ed88c335f0c411a05408",
+        "rev": "ba7c1e41c6e54d6bf9fd1cd013489ac713fc3153",
         "type": "github"
       },
       "original": {
         "owner": "haskell-works",
         "repo": "hw-aeson",
-        "rev": "b5ef03a7d7443fcd6217ed88c335f0c411a05408",
+        "rev": "ba7c1e41c6e54d6bf9fd1cd013489ac713fc3153",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -78,7 +78,7 @@
       flake = false;
     };
     hw-aeson = {
-      url = "github:haskell-works/hw-aeson/b5ef03a7d7443fcd6217ed88c335f0c411a05408";
+      url = "github:haskell-works/hw-aeson/ba7c1e41c6e54d6bf9fd1cd013489ac713fc3153";
       flake = false;
     };
     iohk-monitoring-framework = {

--- a/flake.nix
+++ b/flake.nix
@@ -476,10 +476,7 @@
         formatCheck = formatCheckFor system;
       });
 
-      hydraJobs = {
-        checks = { inherit (self.checks) x86_64-linux; };
-        packages = { inherit (self.packages) x86_64-linux; };
-        devShells = { inherit (self.devShells) x86_64-linux; };
-      };
+      # Instruction for the Hercules CI to build on x86_64-linux only, to avoid errors about systems without agents.
+      herculesCI.ciSystems = [ "x86_64-linux" ];
     };
 }

--- a/src/BotPlutusInterface/Effects.hs
+++ b/src/BotPlutusInterface/Effects.hs
@@ -165,7 +165,6 @@ handlePABEffect contractEnv =
   interpretM
     ( \case
         CallCommand shellArgs -> do
-          print (cmdName shellArgs, cmdArgs shellArgs)
           case contractEnv.cePABConfig.pcCliLocation of
             Local -> callLocalCommand shellArgs
             Remote ipAddr -> callRemoteCommand ipAddr shellArgs


### PR DESCRIPTION
DONE
- plutus-apps uses a version of hw-aeson that breaks for aeson 2.0.0.0 - 2.0.2.0.The updates to hw-aeson aren't breaking, so here we're using a more recent version
- Removes an old print log
- Migrated config from Hydra to Hercules CI
- Tested with Plutip

