### PR TITLE
Update plutus-apps and cardano-node with CHaP

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ ghci: requires_nix_shell
 FORMAT_SOURCES := $(shell fd -e hs)
 
 # Extensions we need to tell fourmolu about
-FORMAT_EXTENSIONS := -o -XTemplateHaskell -o -XTypeApplications -o -XImportQualifiedPost -o -XPatternSynonyms -o -fplugin=RecordDotPreprocessor
+FORMAT_EXTENSIONS := -o -XTemplateHaskell -o -XTypeApplications -o -XImportQualifiedPost -o -XPatternSynonyms
 
 # Run fourmolu formatter
 format: requires_nix_shell

--- a/bot-plutus-interface.cabal
+++ b/bot-plutus-interface.cabal
@@ -24,14 +24,12 @@ source-repository head
 
 common common-lang
   ghc-options:
-    -Wall -Wcompat -Wincomplete-record-updates
-    -Wincomplete-uni-patterns -Wredundant-constraints -fobject-code
-    -fno-ignore-interface-pragmas -fno-omit-interface-pragmas
-    -fplugin=RecordDotPreprocessor -Werror
+    -Wall -Wcompat -Wincomplete-uni-patterns -Wredundant-constraints
+    -fobject-code -fno-ignore-interface-pragmas
+    -fno-omit-interface-pragmas -Werror
 
   build-depends:
     , base
-    , record-dot-preprocessor
     , record-hasfield
 
   default-extensions:

--- a/cabal.project
+++ b/cabal.project
@@ -1,4 +1,16 @@
-index-state: 2022-05-18T00:00:00Z
+repository cardano-haskell-packages
+  url: https://input-output-hk.github.io/cardano-haskell-packages
+  secure: True
+  root-keys:
+    3e0cce471cf09815f930210f7827266fd09045445d65923e6d0238a6cd15126f
+    443abb7fb497a134c343faf52f0b659bd7999bc06b7f63fa76dc99d631f9bea1
+    a86a1f6ce86c449c46666bda44268677abf29b5b2d2eb5ec7af903ec2f117a82
+    bcec67e8e99cabfa7764d75ad9b158d72bfacf70ca1d0ec8bc6b4406d1bf8413
+    c00aae8461a256275598500ea0e187588c35a5d5d7454fb57eac18d9edb86a56
+    d4a35cd3121aa00d18544bb0ac01c3e1691d618f462c46129271bccf39f7e8ee
+
+index-state: 2022-09-27T00:00:00Z
+index-state: cardano-haskell-packages 2022-10-25T20:00:00Z
 
 packages: ./bot-plutus-interface.cabal
           ./examples/plutus-game/plutus-game.cabal
@@ -7,4 +19,167 @@ packages: ./bot-plutus-interface.cabal
 
 tests: true
 benchmarks: true
-test-show-details: direct
+
+allow-newer:
+    *:aeson
+  , size-based:template-haskell
+
+constraints:
+  -- cardano-prelude-0.1.0.0 needs
+  , protolude <0.3.1
+
+  -- cardano-ledger-byron-0.1.0.0 needs
+  , cardano-binary <1.5.0.1
+
+  -- plutus-core-1.0.0.1 needs
+  , cardano-crypto-class >2.0.0.0
+  , algebraic-graphs <0.7
+
+  -- cardano-ledger-core-0.1.0.0 needs
+  , cardano-crypto-class <2.0.0.1
+
+  -- cardano-crypto-class-2.0.0.0.1 needs
+  , cardano-prelude <0.1.0.1
+
+  -- dbvar from cardano-wallet needs
+  , io-classes <0.3.0.0
+
+  -- newer typed-protocols need io-classes>=0.3.0.0 which is incompatible with dbvar's constraint above
+  , typed-protocols==0.1.0.0
+
+extra-packages:
+    ouroboros-consensus-cardano-tools == 0.1.0.0
+
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/plutus-apps
+  tag: 0951b871d6e1a8ec950d277c1f98920808199b12
+  --sha256: 1zv5qwivfifg6wpnz0l4rkp5dwyl2lv6ljlrx42k0f51zjga8yp5
+  subdir:
+    cardano-streaming
+    doc
+    freer-extras
+    marconi
+    marconi-mamba
+    playground-common
+    pab-blockfrost
+    plutus-chain-index
+    plutus-chain-index-core
+    plutus-contract
+    plutus-contract-certification
+    plutus-example
+    plutus-ledger
+    plutus-ledger-constraints
+    plutus-pab
+    plutus-pab-executables
+    plutus-script-utils
+    plutus-tx-constraints
+    plutus-use-cases
+    rewindable-index
+
+source-repository-package
+  type: git
+  location: https://github.com/gege251/cardano-wallet
+  tag: ee5fd7d201ed7d6b2deaf1557f492d04ded5f1a6
+  --sha256: 14z1n1562bds5wjbzq9bm3wk8b0xma3i8si23l8z7hq8zzrwiql6
+  subdir:
+    lib/cli
+    lib/core
+    lib/core-integration
+    lib/dbvar
+    lib/launcher
+    lib/numeric
+    lib/shelley
+    lib/strict-non-empty-containers
+    lib/test-utils
+    lib/text-class
+
+source-repository-package
+    type: git
+    location: https://github.com/input-output-hk/cardano-addresses
+    tag: b7273a5d3c21f1a003595ebf1e1f79c28cd72513
+    --sha256: 129r5kyiw10n2021bkdvnr270aiiwyq58h472d151ph0r7wpslgp
+    subdir:
+      command-line
+      core
+
+source-repository-package
+   type: git
+   location: https://github.com/input-output-hk/cardano-node
+   tag: 1.35.4
+   --sha256: 1j01m2cp2vdcl26zx9xmipr551v3b2rz9kfn9ik8byfwj1z7652r
+   subdir:
+     cardano-api
+     cardano-cli
+     cardano-client-demo
+     cardano-git-rev
+     cardano-node
+     cardano-node-capi
+     cardano-node-chairman
+     cardano-submit-api
+     cardano-testnet
+     cardano-tracer
+     bench/cardano-topology
+     bench/locli
+     bench/tx-generator
+     trace-dispatcher
+     trace-resources
+     trace-forward
+
+source-repository-package
+  type: git
+  location: https://github.com/denisshevchenko/threepenny-gui
+  tag: 4ec92ded05ccf59ba4a874be4b404ac1b6d666b6
+  --sha256: 00fvvaf4ir4hskq4a6gggbh2wmdvy8j8kn6s4m1p1vlh8m8mq514
+
+-- Direct dependencies of plutus-apps
+
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/servant-purescript
+  tag: 44e7cacf109f84984cd99cd3faf185d161826963
+  --sha256: 10pb0yfp80jhb9ryn65a4rha2lxzsn2vlhcc6xphrrkf4x5lhzqc
+
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/purescript-bridge
+  tag: 47a1f11825a0f9445e0f98792f79172efef66c00
+  --sha256: 0da1vn2l6iyfxcjk58qal1l4755v92zi6yppmjmqvxf1gacyf9px
+
+source-repository-package
+    type: git
+    location: https://github.com/input-output-hk/quickcheck-dynamic
+    tag: c272906361471d684440f76c297e29ab760f6a1e
+    --sha256: 1b9ppgavqad78a2z1zxv7v4jasjz6zz0mxkr0zx0bbcd0i00jajf
+
+-- This is needed because we rely on an unreleased feature
+-- https://github.com/input-output-hk/cardano-ledger/pull/3111
+source-repository-package
+    type: git
+    location: https://github.com/input-output-hk/cardano-ledger
+    tag: da3e9ae10cf9ef0b805a046c84745f06643583c2
+    --sha256: 1jg1h05gcms119mw7fz798xpj3hr5h426ga934vixmgf88m1jmfx
+    subdir:
+      eras/alonzo/impl
+      eras/alonzo/test-suite
+      eras/babbage/impl
+      eras/babbage/test-suite
+      eras/byron/chain/executable-spec
+      eras/byron/crypto
+      eras/byron/crypto/test
+      eras/byron/ledger/executable-spec
+      eras/byron/ledger/impl
+      eras/byron/ledger/impl/test
+      eras/shelley/impl
+      eras/shelley/test-suite
+      eras/shelley-ma/impl
+      eras/shelley-ma/test-suite
+      libs/cardano-ledger-core
+      libs/cardano-ledger-pretty
+      libs/cardano-protocol-tpraos
+      libs/cardano-data
+      libs/vector-map
+      libs/set-algebra
+      libs/small-steps
+      libs/small-steps-test
+      libs/non-integral

--- a/examples/plutus-game/plutus-game.cabal
+++ b/examples/plutus-game/plutus-game.cabal
@@ -25,11 +25,10 @@ common common-lang
     -Wall -Wcompat -Wincomplete-record-updates
     -Wincomplete-uni-patterns -Wredundant-constraints -Werror
     -fobject-code -fno-ignore-interface-pragmas
-    -fno-omit-interface-pragmas -fplugin=RecordDotPreprocessor
+    -fno-omit-interface-pragmas
 
   build-depends:
-    , base                     ^>=4.14
-    , record-dot-preprocessor
+    , base             ^>=4.14
     , record-hasfield
 
   default-extensions:

--- a/examples/plutus-nft/plutus-nft.cabal
+++ b/examples/plutus-nft/plutus-nft.cabal
@@ -25,11 +25,10 @@ common common-lang
     -Wall -Wcompat -Wincomplete-record-updates
     -Wincomplete-uni-patterns -Wredundant-constraints -Werror
     -fobject-code -fno-ignore-interface-pragmas
-    -fno-omit-interface-pragmas -fplugin=RecordDotPreprocessor
+    -fno-omit-interface-pragmas
 
   build-depends:
-    , base                     ^>=4.14
-    , record-dot-preprocessor
+    , base             ^>=4.14
     , record-hasfield
 
   default-extensions:

--- a/examples/plutus-nft/src/Cardano/PlutusExample/NFT.hs
+++ b/examples/plutus-nft/src/Cardano/PlutusExample/NFT.hs
@@ -26,6 +26,7 @@ import Ledger (
   TxOutRef,
   ownCurrencySymbol,
   pubKeyHashAddress,
+  stakePubKeyHashCredential,
  )
 import Ledger.Address (StakePubKeyHash)
 import Ledger.Constraints as Constraints
@@ -111,7 +112,7 @@ mintNft MintParams {..} = do
             Hask.mconcat
               [ Constraints.mustMintValue val
               , Constraints.mustSpendPubKeyOutput oref
-              , Constraints.mustPayToPubKeyAddress mpPubKeyHash mpStakeHash val
+              , Constraints.mustPayToPubKeyAddress mpPubKeyHash (stakePubKeyHashCredential mpStakeHash) val
               ]
           tokenMetadata = NftMetadataToken mpName mpImage (Just "image/jpeg") mpDescription Hask.mempty Hask.mempty
           txMetadata = TxMetadata (Just $ NftMetadata $ Map.singleton cs $ Map.singleton mpTokenName tokenMetadata) Hask.mempty

--- a/examples/plutus-transfer/plutus-transfer.cabal
+++ b/examples/plutus-transfer/plutus-transfer.cabal
@@ -25,11 +25,10 @@ common common-lang
     -Wall -Wcompat -Wincomplete-record-updates
     -Wincomplete-uni-patterns -Wredundant-constraints -Werror
     -fobject-code -fno-ignore-interface-pragmas
-    -fno-omit-interface-pragmas -fplugin=RecordDotPreprocessor
+    -fno-omit-interface-pragmas
 
   build-depends:
-    , base                     ^>=4.14
-    , record-dot-preprocessor
+    , base             ^>=4.14
     , record-hasfield
 
   default-extensions:

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,22 @@
 {
   "nodes": {
+    "CHaP": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1669289866,
+        "narHash": "sha256-dnRYWjYZQuNJLXsn5PdcMBPaReDYVARqc8a2grokVZ0=",
+        "owner": "input-output-hk",
+        "repo": "cardano-haskell-packages",
+        "rev": "c3cebaddd8b60c0b5bcef6d895adb30a79f495a8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "ref": "repo",
+        "repo": "cardano-haskell-packages",
+        "type": "github"
+      }
+    },
     "HTTP": {
       "flake": false,
       "locked": {
@@ -16,20 +33,18 @@
         "type": "github"
       }
     },
-    "Win32-network": {
-      "flake": false,
+    "blank": {
       "locked": {
-        "lastModified": 1627315969,
-        "narHash": "sha256-Hesb5GXSx0IwKSIi42ofisVELcQNX6lwHcoZcbaDiqc=",
-        "owner": "input-output-hk",
-        "repo": "Win32-network",
-        "rev": "3825d3abf75f83f406c1f7161883c438dac7277d",
+        "lastModified": 1625557891,
+        "narHash": "sha256-O8/MWsPBGhhyPoPLHZAuoZiiHo9q6FLlEeIDEXuj6T4=",
+        "owner": "divnix",
+        "repo": "blank",
+        "rev": "5a5d2684073d9f563072ed07c871d577a6c614a8",
         "type": "github"
       },
       "original": {
-        "owner": "input-output-hk",
-        "repo": "Win32-network",
-        "rev": "3825d3abf75f83f406c1f7161883c438dac7277d",
+        "owner": "divnix",
+        "repo": "blank",
         "type": "github"
       }
     },
@@ -84,125 +99,6 @@
         "type": "github"
       }
     },
-    "cardano-addresses": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1660105670,
-        "narHash": "sha256-91F9+ckA3lBCE4dAVLDnMSpwRLa7zRUEEBYEHv0sOYk=",
-        "owner": "input-output-hk",
-        "repo": "cardano-addresses",
-        "rev": "b7273a5d3c21f1a003595ebf1e1f79c28cd72513",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "repo": "cardano-addresses",
-        "rev": "b7273a5d3c21f1a003595ebf1e1f79c28cd72513",
-        "type": "github"
-      }
-    },
-    "cardano-base": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1654537609,
-        "narHash": "sha256-4b0keLjRaVSdEwfBXB1iT3QPlsutdxSltGfBufT4Clw=",
-        "owner": "input-output-hk",
-        "repo": "cardano-base",
-        "rev": "0f3a867493059e650cda69e20a5cbf1ace289a57",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "repo": "cardano-base",
-        "rev": "0f3a867493059e650cda69e20a5cbf1ace289a57",
-        "type": "github"
-      }
-    },
-    "cardano-config": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1642737642,
-        "narHash": "sha256-TNbpnR7llUgBN2WY7CryMxNVupBIUH01h1hRNHoxboY=",
-        "owner": "input-output-hk",
-        "repo": "cardano-config",
-        "rev": "1646e9167fab36c0bff82317743b96efa2d3adaa",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "repo": "cardano-config",
-        "rev": "1646e9167fab36c0bff82317743b96efa2d3adaa",
-        "type": "github"
-      }
-    },
-    "cardano-crypto": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1604244485,
-        "narHash": "sha256-2Fipex/WjIRMrvx6F3hjJoAeMtFd2wGnZECT0kuIB9k=",
-        "owner": "input-output-hk",
-        "repo": "cardano-crypto",
-        "rev": "f73079303f663e028288f9f4a9e08bcca39a923e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "repo": "cardano-crypto",
-        "rev": "f73079303f663e028288f9f4a9e08bcca39a923e",
-        "type": "github"
-      }
-    },
-    "cardano-ledger": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1659038626,
-        "narHash": "sha256-zTQbMOGPD1Oodv6VUsfF6NUiXkbN8SWI98W3Atv4wbI=",
-        "owner": "input-output-hk",
-        "repo": "cardano-ledger",
-        "rev": "c7c63dabdb215ebdaed8b63274965966f2bf408f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "repo": "cardano-ledger",
-        "rev": "c7c63dabdb215ebdaed8b63274965966f2bf408f",
-        "type": "github"
-      }
-    },
-    "cardano-node": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1659625017,
-        "narHash": "sha256-4IrheFeoWfvkZQndEk4fGUkOiOjcVhcyXZ6IqmvkDgg=",
-        "owner": "input-output-hk",
-        "repo": "cardano-node",
-        "rev": "950c4e222086fed5ca53564e642434ce9307b0b9",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "ref": "1.35.3",
-        "repo": "cardano-node",
-        "type": "github"
-      }
-    },
-    "cardano-prelude": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1617089317,
-        "narHash": "sha256-kgX3DKyfjBb8/XcDEd+/adlETsFlp5sCSurHWgsFAQI=",
-        "owner": "input-output-hk",
-        "repo": "cardano-prelude",
-        "rev": "bb4ed71ba8e587f672d06edf9d2e376f4b055555",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "repo": "cardano-prelude",
-        "rev": "bb4ed71ba8e587f672d06edf9d2e376f4b055555",
-        "type": "github"
-      }
-    },
     "cardano-shell": {
       "flake": false,
       "locked": {
@@ -219,58 +115,97 @@
         "type": "github"
       }
     },
-    "cardano-wallet": {
-      "flake": false,
+    "devshell": {
+      "inputs": {
+        "flake-utils": [
+          "haskell-nix",
+          "tullia",
+          "std",
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "haskell-nix",
+          "tullia",
+          "std",
+          "nixpkgs"
+        ]
+      },
       "locked": {
-        "lastModified": 1660141505,
-        "narHash": "sha256-3Rnj/g3KLzOW5YSieqsUa9IF1Td22Eskk5KuVsOFgEQ=",
-        "owner": "input-output-hk",
-        "repo": "cardano-wallet",
-        "rev": "18a931648550246695c790578d4a55ee2f10463e",
+        "lastModified": 1663445644,
+        "narHash": "sha256-+xVlcK60x7VY1vRJbNUEAHi17ZuoQxAIH4S4iUFUGBA=",
+        "owner": "numtide",
+        "repo": "devshell",
+        "rev": "e3dc3e21594fe07bdb24bdf1c8657acaa4cb8f66",
         "type": "github"
       },
       "original": {
-        "owner": "input-output-hk",
-        "repo": "cardano-wallet",
-        "rev": "18a931648550246695c790578d4a55ee2f10463e",
+        "owner": "numtide",
+        "repo": "devshell",
         "type": "github"
       }
     },
-    "ekg-forward": {
-      "flake": false,
+    "dmerge": {
+      "inputs": {
+        "nixlib": [
+          "haskell-nix",
+          "tullia",
+          "std",
+          "nixpkgs"
+        ],
+        "yants": [
+          "haskell-nix",
+          "tullia",
+          "std",
+          "yants"
+        ]
+      },
       "locked": {
-        "lastModified": 1642052814,
-        "narHash": "sha256-jwj/gh/A/PXhO6yVESV27k4yx9I8Id8fTa3m4ofPnP0=",
-        "owner": "input-output-hk",
-        "repo": "ekg-forward",
-        "rev": "297cd9db5074339a2fb2e5ae7d0780debb670c63",
+        "lastModified": 1659548052,
+        "narHash": "sha256-fzI2gp1skGA8mQo/FBFrUAtY0GQkAIAaV/V127TJPyY=",
+        "owner": "divnix",
+        "repo": "data-merge",
+        "rev": "d160d18ce7b1a45b88344aa3f13ed1163954b497",
         "type": "github"
       },
       "original": {
-        "owner": "input-output-hk",
-        "repo": "ekg-forward",
-        "rev": "297cd9db5074339a2fb2e5ae7d0780debb670c63",
-        "type": "github"
-      }
-    },
-    "ekg-json": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1642583945,
-        "narHash": "sha256-VT8Ur585TCn03P2TVi6t92v2Z6tl8vKijICjse6ocv8=",
-        "owner": "vshabanov",
-        "repo": "ekg-json",
-        "rev": "00ebe7211c981686e65730b7144fbf5350462608",
-        "type": "github"
-      },
-      "original": {
-        "owner": "vshabanov",
-        "repo": "ekg-json",
-        "rev": "00ebe7211c981686e65730b7144fbf5350462608",
+        "owner": "divnix",
+        "repo": "data-merge",
         "type": "github"
       }
     },
     "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1668681692,
+        "narHash": "sha256-Ht91NGdewz8IQLtWZ9LCeNXMSXHUss+9COoqu6JLmXU=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "009399224d5e398d03b22badca40a37ac85412a1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1635892615,
+        "narHash": "sha256-harGbMZr4hzat2BWBU+Y5OYXlu+fVz7E4WeQzHi5o8A=",
+        "owner": "input-output-hk",
+        "repo": "flake-compat",
+        "rev": "eca47d3377946315596da653862d341ee5341318",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_3": {
       "flake": false,
       "locked": {
         "lastModified": 1650374568,
@@ -301,20 +236,48 @@
         "type": "github"
       }
     },
-    "flat": {
-      "flake": false,
+    "flake-utils_2": {
       "locked": {
-        "lastModified": 1628771504,
-        "narHash": "sha256-lRFND+ZnZvAph6ZYkr9wl9VAx41pb3uSFP8Wc7idP9M=",
-        "owner": "Quid2",
-        "repo": "flat",
-        "rev": "ee59880f47ab835dbd73bea0847dab7869fc20d8",
+        "lastModified": 1653893745,
+        "narHash": "sha256-0jntwV3Z8//YwuOjzhV2sgJJPt+HY6KhU7VZUL0fKZQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "1ed9fb1935d260de5fe1c2f7ee0ebaae17ed2fa1",
         "type": "github"
       },
       "original": {
-        "owner": "Quid2",
-        "repo": "flat",
-        "rev": "ee59880f47ab835dbd73bea0847dab7869fc20d8",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_3": {
+      "locked": {
+        "lastModified": 1659877975,
+        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_4": {
+      "locked": {
+        "lastModified": 1653893745,
+        "narHash": "sha256-0jntwV3Z8//YwuOjzhV2sgJJPt+HY6KhU7VZUL0fKZQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "1ed9fb1935d260de5fe1c2f7ee0ebaae17ed2fa1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
         "type": "github"
       }
     },
@@ -335,31 +298,33 @@
         "type": "github"
       }
     },
-    "goblins": {
-      "flake": false,
+    "gomod2nix": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_2",
+        "utils": "utils"
+      },
       "locked": {
-        "lastModified": 1598362523,
-        "narHash": "sha256-z9ut0y6umDIjJIRjz9KSvKgotuw06/S8QDwOtVdGiJ0=",
-        "owner": "input-output-hk",
-        "repo": "goblins",
-        "rev": "cde90a2b27f79187ca8310b6549331e59595e7ba",
+        "lastModified": 1655245309,
+        "narHash": "sha256-d/YPoQ/vFn1+GTmSdvbSBSTOai61FONxB4+Lt6w/IVI=",
+        "owner": "tweag",
+        "repo": "gomod2nix",
+        "rev": "40d32f82fc60d66402eb0972e6e368aeab3faf58",
         "type": "github"
       },
       "original": {
-        "owner": "input-output-hk",
-        "repo": "goblins",
-        "rev": "cde90a2b27f79187ca8310b6549331e59595e7ba",
+        "owner": "tweag",
+        "repo": "gomod2nix",
         "type": "github"
       }
     },
     "hackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1653441966,
-        "narHash": "sha256-aJFK0wDzoOrtb7ucZzKh5J+S2pThpwNCofl74s1olXU=",
+        "lastModified": 1669338728,
+        "narHash": "sha256-a+/QK3TeSgzLnL1z/EkqROo3cwB6VXV3BmvkvvGPSzM=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "f7fe6ef8de52c43a9efa6fd4ac4902e5957dc573",
+        "rev": "d044e9fd6eb02330eda094e3b7a61d4d23f8544a",
         "type": "github"
       },
       "original": {
@@ -375,51 +340,35 @@
         "cabal-34": "cabal-34",
         "cabal-36": "cabal-36",
         "cardano-shell": "cardano-shell",
+        "flake-compat": "flake-compat_2",
         "flake-utils": "flake-utils",
         "ghc-8.6.5-iohk": "ghc-8.6.5-iohk",
         "hackage": "hackage",
         "hpc-coveralls": "hpc-coveralls",
         "hydra": "hydra",
-        "nix-tools": "nix-tools",
         "nixpkgs": [
-          "haskell-nix",
-          "nixpkgs-unstable"
+          "nixpkgs"
         ],
         "nixpkgs-2003": "nixpkgs-2003",
         "nixpkgs-2105": "nixpkgs-2105",
         "nixpkgs-2111": "nixpkgs-2111",
+        "nixpkgs-2205": "nixpkgs-2205",
         "nixpkgs-unstable": "nixpkgs-unstable",
         "old-ghc-nix": "old-ghc-nix",
-        "stackage": "stackage"
+        "stackage": "stackage",
+        "tullia": "tullia"
       },
       "locked": {
-        "lastModified": 1653486569,
-        "narHash": "sha256-342b0LPX6kaBuEX8KZV40FwCCFre1lCtjdTQIDEt9kw=",
-        "owner": "mlabs-haskell",
-        "repo": "haskell.nix",
-        "rev": "220f8a9cd166e726aea62843bdafa7ecded3375c",
-        "type": "github"
-      },
-      "original": {
-        "owner": "mlabs-haskell",
-        "repo": "haskell.nix",
-        "type": "github"
-      }
-    },
-    "hedgehog-extras": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1656051321,
-        "narHash": "sha256-6KQFEzb9g2a0soVvwLKESEbA+a8ygpROcMr6bkatROE=",
+        "lastModified": 1669338917,
+        "narHash": "sha256-jwZ/I4VXGvpDkC/59c3rQPNBpQdTirJwXEu5KejJIHo=",
         "owner": "input-output-hk",
-        "repo": "hedgehog-extras",
-        "rev": "714ee03a5a786a05fc57ac5d2f1c2edce4660d85",
+        "repo": "haskell.nix",
+        "rev": "7f8ccbda20e5ab12780162f045656061334b531a",
         "type": "github"
       },
       "original": {
         "owner": "input-output-hk",
-        "repo": "hedgehog-extras",
-        "rev": "714ee03a5a786a05fc57ac5d2f1c2edce4660d85",
+        "repo": "haskell.nix",
         "type": "github"
       }
     },
@@ -436,23 +385,6 @@
       "original": {
         "owner": "sevanspowell",
         "repo": "hpc-coveralls",
-        "type": "github"
-      }
-    },
-    "hw-aeson": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1660113261,
-        "narHash": "sha256-v0SyVxeVBTtW1tuej4P+Kf4roO/rr2tBI7RthTlInbc=",
-        "owner": "haskell-works",
-        "repo": "hw-aeson",
-        "rev": "b5ef03a7d7443fcd6217ed88c335f0c411a05408",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell-works",
-        "repo": "hw-aeson",
-        "rev": "b5ef03a7d7443fcd6217ed88c335f0c411a05408",
         "type": "github"
       }
     },
@@ -479,48 +411,18 @@
         "type": "indirect"
       }
     },
-    "io-sim": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1654253725,
-        "narHash": "sha256-TviSvCBEYtlKEo9qJmE8pCE25nMjDi8HeIAFniunaM8=",
-        "owner": "input-output-hk",
-        "repo": "io-sim",
-        "rev": "57e888b1894829056cb00b7b5785fdf6a74c3271",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "repo": "io-sim",
-        "rev": "57e888b1894829056cb00b7b5785fdf6a74c3271",
-        "type": "github"
-      }
-    },
-    "iohk-monitoring-framework": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1653619339,
-        "narHash": "sha256-0ia5UflYEmBYepj2gkJy9msknklI0UPtUavMEGwk3Wg=",
-        "owner": "input-output-hk",
-        "repo": "iohk-monitoring-framework",
-        "rev": "066f7002aac5a0efc20e49643fea45454f226caa",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "repo": "iohk-monitoring-framework",
-        "rev": "066f7002aac5a0efc20e49643fea45454f226caa",
-        "type": "github"
-      }
-    },
     "iohk-nix": {
-      "flake": false,
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
       "locked": {
-        "lastModified": 1658222743,
-        "narHash": "sha256-yFH01psqx30y5Ws4dBElLkxYpIxxqZx4G+jCVhsXpnA=",
+        "lastModified": 1667394105,
+        "narHash": "sha256-YhS7zGd6jK/QM/+wWyj0zUBZmE3HOXAL/kpJptGYIWg=",
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "9a604d01bd4420ab7f396f14d1947fbe2ce7db8b",
+        "rev": "7fc7625a9ab2ba137bc70ddbc89a13d3fdb78c8b",
         "type": "github"
       },
       "original": {
@@ -545,6 +447,46 @@
         "type": "github"
       }
     },
+    "mdbook-kroki-preprocessor": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1661755005,
+        "narHash": "sha256-1TJuUzfyMycWlOQH67LR63/ll2GDZz25I3JfScy/Jnw=",
+        "owner": "JoelCourtney",
+        "repo": "mdbook-kroki-preprocessor",
+        "rev": "93adb5716d035829efed27f65f2f0833a7d3e76f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "JoelCourtney",
+        "repo": "mdbook-kroki-preprocessor",
+        "type": "github"
+      }
+    },
+    "n2c": {
+      "inputs": {
+        "flake-utils": "flake-utils_4",
+        "nixpkgs": [
+          "haskell-nix",
+          "tullia",
+          "std",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1665039323,
+        "narHash": "sha256-SAh3ZjFGsaCI8FRzXQyp56qcGdAqgKEfJWPCQ0Sr7tQ=",
+        "owner": "nlewo",
+        "repo": "nix2container",
+        "rev": "b008fe329ffb59b67bf9e7b08ede6ee792f2741a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nlewo",
+        "repo": "nix2container",
+        "type": "github"
+      }
+    },
     "nix": {
       "inputs": {
         "lowdown-src": "lowdown-src",
@@ -566,19 +508,92 @@
         "type": "github"
       }
     },
-    "nix-tools": {
-      "flake": false,
+    "nix-nomad": {
+      "inputs": {
+        "flake-compat": "flake-compat_3",
+        "flake-utils": [
+          "haskell-nix",
+          "tullia",
+          "nix2container",
+          "flake-utils"
+        ],
+        "gomod2nix": "gomod2nix",
+        "nixpkgs": [
+          "haskell-nix",
+          "tullia",
+          "nixpkgs"
+        ],
+        "nixpkgs-lib": [
+          "haskell-nix",
+          "tullia",
+          "nixpkgs"
+        ]
+      },
       "locked": {
-        "lastModified": 1649424170,
-        "narHash": "sha256-XgKXWispvv5RCvZzPb+p7e6Hy3LMuRjafKMl7kXzxGw=",
-        "owner": "input-output-hk",
-        "repo": "nix-tools",
-        "rev": "e109c94016e3b6e0db7ed413c793e2d4bdb24aa7",
+        "lastModified": 1658277770,
+        "narHash": "sha256-T/PgG3wUn8Z2rnzfxf2VqlR1CBjInPE0l1yVzXxPnt0=",
+        "owner": "tristanpemble",
+        "repo": "nix-nomad",
+        "rev": "054adcbdd0a836ae1c20951b67ed549131fd2d70",
         "type": "github"
       },
       "original": {
-        "owner": "input-output-hk",
-        "repo": "nix-tools",
+        "owner": "tristanpemble",
+        "repo": "nix-nomad",
+        "type": "github"
+      }
+    },
+    "nix2container": {
+      "inputs": {
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": "nixpkgs_3"
+      },
+      "locked": {
+        "lastModified": 1658567952,
+        "narHash": "sha256-XZ4ETYAMU7XcpEeAFP3NOl9yDXNuZAen/aIJ84G+VgA=",
+        "owner": "nlewo",
+        "repo": "nix2container",
+        "rev": "60bb43d405991c1378baf15a40b5811a53e32ffa",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nlewo",
+        "repo": "nix2container",
+        "type": "github"
+      }
+    },
+    "nixago": {
+      "inputs": {
+        "flake-utils": [
+          "haskell-nix",
+          "tullia",
+          "std",
+          "flake-utils"
+        ],
+        "nixago-exts": [
+          "haskell-nix",
+          "tullia",
+          "std",
+          "blank"
+        ],
+        "nixpkgs": [
+          "haskell-nix",
+          "tullia",
+          "std",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1661824785,
+        "narHash": "sha256-/PnwdWoO/JugJZHtDUioQp3uRiWeXHUdgvoyNbXesz8=",
+        "owner": "nix-community",
+        "repo": "nixago",
+        "rev": "8c1f9e5f1578d4b2ea989f618588d62a335083c3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixago",
         "type": "github"
       }
     },
@@ -615,11 +630,11 @@
     },
     "nixpkgs-2105": {
       "locked": {
-        "lastModified": 1645296114,
-        "narHash": "sha256-y53N7TyIkXsjMpOG7RhvqJFGDacLs9HlyHeSTBioqYU=",
+        "lastModified": 1659914493,
+        "narHash": "sha256-lkA5X3VNMKirvA+SUzvEhfA7XquWLci+CGi505YFAIs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "530a53dcbc9437363471167a5e4762c5fcfa34a1",
+        "rev": "022caabb5f2265ad4006c1fa5b1ebe69fb0c3faf",
         "type": "github"
       },
       "original": {
@@ -631,16 +646,32 @@
     },
     "nixpkgs-2111": {
       "locked": {
-        "lastModified": 1648744337,
-        "narHash": "sha256-bYe1dFJAXovjqiaPKrmAbSBEK5KUkgwVaZcTbSoJ7hg=",
+        "lastModified": 1659446231,
+        "narHash": "sha256-hekabNdTdgR/iLsgce5TGWmfIDZ86qjPhxDg/8TlzhE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0a58eebd8ec65ffdef2ce9562784123a73922052",
+        "rev": "eabc38219184cc3e04a974fe31857d8e0eac098d",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "ref": "nixpkgs-21.11-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2205": {
+      "locked": {
+        "lastModified": 1663981975,
+        "narHash": "sha256-TKaxWAVJR+a5JJauKZqibmaM5e/Pi5tBDx9s8fl/kSE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "309faedb8338d3ae8ad8f1043b3ccf48c9cc2970",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-22.05-darwin",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -662,15 +693,62 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1648219316,
-        "narHash": "sha256-Ctij+dOi0ZZIfX5eMhgwugfvB+WZSrvVNAyAuANOsnQ=",
+        "lastModified": 1663905476,
+        "narHash": "sha256-0CSwRKaYravh9v6qSlBpM0gNg0UhKT2lL7Yn6Zbx7UM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "30d3d79b7d3607d56546dd2a6b49e156ba0ec634",
+        "rev": "e14f9fb57315f0d4abde222364f19f88c77d2b79",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1653581809,
+        "narHash": "sha256-Uvka0V5MTGbeOfWte25+tfRL3moECDh1VwokWSZUdoY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "83658b28fe638a170a19b8933aa008b30640fbd1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_3": {
+      "locked": {
+        "lastModified": 1654807842,
+        "narHash": "sha256-ADymZpr6LuTEBXcy6RtFHcUZdjKTBRTMYwu19WOx17E=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "fc909087cc3386955f21b4665731dbdaceefb1d8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_4": {
+      "locked": {
+        "lastModified": 1665087388,
+        "narHash": "sha256-FZFPuW9NWHJteATOf79rZfwfRn5fE0wi9kRzvGfDHPA=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "95fda953f6db2e9496d2682c4fc7b82f959878f7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
         "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
@@ -693,169 +771,26 @@
         "type": "github"
       }
     },
-    "optparse-applicative": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1628901899,
-        "narHash": "sha256-uQx+SEYsCH7JcG3xAT0eJck9yq3y0cvx49bvItLLer8=",
-        "owner": "input-output-hk",
-        "repo": "optparse-applicative",
-        "rev": "7497a29cb998721a9068d5725d49461f2bba0e7a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "repo": "optparse-applicative",
-        "rev": "7497a29cb998721a9068d5725d49461f2bba0e7a",
-        "type": "github"
-      }
-    },
-    "ouroboros-network": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1658339771,
-        "narHash": "sha256-3ElbHM1B5u1QD0aes1KbaX2FxKJzU05H0OzJ36em1Bg=",
-        "owner": "input-output-hk",
-        "repo": "ouroboros-network",
-        "rev": "cb9eba406ceb2df338d8384b35c8addfe2067201",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "repo": "ouroboros-network",
-        "rev": "cb9eba406ceb2df338d8384b35c8addfe2067201",
-        "type": "github"
-      }
-    },
-    "plutus-apps": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1667491945,
-        "narHash": "sha256-gVqaGFMlXU4HdMWRzRTzNG+WPUOtPr3GLHGhAtKOuuY=",
-        "owner": "input-output-hk",
-        "repo": "plutus-apps",
-        "rev": "a2045141fc0b4f14470ebf4679c6abe40aac4db7",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "repo": "plutus-apps",
-        "rev": "a2045141fc0b4f14470ebf4679c6abe40aac4db7",
-        "type": "github"
-      }
-    },
-    "plutus-core": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1659046871,
-        "narHash": "sha256-coD/Kpl7tutwXb6ukQCH5XojBjquYkW7ob0BWZtdpok=",
-        "owner": "input-output-hk",
-        "repo": "plutus",
-        "rev": "a56c96598b4b25c9e28215214d25189331087244",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "repo": "plutus",
-        "rev": "a56c96598b4b25c9e28215214d25189331087244",
-        "type": "github"
-      }
-    },
-    "purescript-bridge": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1642802224,
-        "narHash": "sha256-/SbnmXrB9Y2rrPd6E79Iu5RDaKAKozIl685HQ4XdQTU=",
-        "owner": "input-output-hk",
-        "repo": "purescript-bridge",
-        "rev": "47a1f11825a0f9445e0f98792f79172efef66c00",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "repo": "purescript-bridge",
-        "rev": "47a1f11825a0f9445e0f98792f79172efef66c00",
-        "type": "github"
-      }
-    },
-    "quickcheck-dynamic": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1656927450,
-        "narHash": "sha256-TioJQASNrQX6B3n2Cv43X2olyT67//CFQqcpvNW7N60=",
-        "owner": "input-output-hk",
-        "repo": "quickcheck-dynamic",
-        "rev": "c272906361471d684440f76c297e29ab760f6a1e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "repo": "quickcheck-dynamic",
-        "rev": "c272906361471d684440f76c297e29ab760f6a1e",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
-        "Win32-network": "Win32-network",
-        "cardano-addresses": "cardano-addresses",
-        "cardano-base": "cardano-base",
-        "cardano-config": "cardano-config",
-        "cardano-crypto": "cardano-crypto",
-        "cardano-ledger": "cardano-ledger",
-        "cardano-node": "cardano-node",
-        "cardano-prelude": "cardano-prelude",
-        "cardano-wallet": "cardano-wallet",
-        "ekg-forward": "ekg-forward",
-        "ekg-json": "ekg-json",
+        "CHaP": "CHaP",
         "flake-compat": "flake-compat",
-        "flat": "flat",
-        "goblins": "goblins",
         "haskell-nix": "haskell-nix",
-        "hedgehog-extras": "hedgehog-extras",
-        "hw-aeson": "hw-aeson",
-        "io-sim": "io-sim",
-        "iohk-monitoring-framework": "iohk-monitoring-framework",
         "iohk-nix": "iohk-nix",
         "nixpkgs": [
           "haskell-nix",
           "nixpkgs-unstable"
-        ],
-        "optparse-applicative": "optparse-applicative",
-        "ouroboros-network": "ouroboros-network",
-        "plutus-apps": "plutus-apps",
-        "plutus-core": "plutus-core",
-        "purescript-bridge": "purescript-bridge",
-        "quickcheck-dynamic": "quickcheck-dynamic",
-        "servant-purescript": "servant-purescript",
-        "typed-protocols": "typed-protocols"
-      }
-    },
-    "servant-purescript": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1642798070,
-        "narHash": "sha256-DH9ISydu5gxvN4xBuoXVv1OhYCaqGOtzWlACdJ0H64I=",
-        "owner": "input-output-hk",
-        "repo": "servant-purescript",
-        "rev": "44e7cacf109f84984cd99cd3faf185d161826963",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "repo": "servant-purescript",
-        "rev": "44e7cacf109f84984cd99cd3faf185d161826963",
-        "type": "github"
+        ]
       }
     },
     "stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1653355076,
-        "narHash": "sha256-mQdOgAyFkLUJBPrVDZmZQ2JRtgHKOQkil//SDdcjP1U=",
+        "lastModified": 1669338854,
+        "narHash": "sha256-D9WBn+cC8t8Xu+z+H0nDGoeOCcqsbDGXHsaO7qY45O4=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "71b16ca68d6acd639121db43238896357fe53f54",
+        "rev": "e9c817e14342ebef9fcf433f6ba3aa00c6df3e3f",
         "type": "github"
       },
       "original": {
@@ -864,20 +799,103 @@
         "type": "github"
       }
     },
-    "typed-protocols": {
-      "flake": false,
+    "std": {
+      "inputs": {
+        "blank": "blank",
+        "devshell": "devshell",
+        "dmerge": "dmerge",
+        "flake-utils": "flake-utils_3",
+        "makes": [
+          "haskell-nix",
+          "tullia",
+          "std",
+          "blank"
+        ],
+        "mdbook-kroki-preprocessor": "mdbook-kroki-preprocessor",
+        "microvm": [
+          "haskell-nix",
+          "tullia",
+          "std",
+          "blank"
+        ],
+        "n2c": "n2c",
+        "nixago": "nixago",
+        "nixpkgs": "nixpkgs_4",
+        "yants": "yants"
+      },
       "locked": {
-        "lastModified": 1653046676,
-        "narHash": "sha256-5Wof5yTKb12EPY6B8LfapX18xNZZpF+rvhnQ88U6KdM=",
+        "lastModified": 1665513321,
+        "narHash": "sha256-D6Pacw9yf/HMs84KYuCxHXnNDL7v43gtcka5URagFqE=",
+        "owner": "divnix",
+        "repo": "std",
+        "rev": "94a90eedb9cfc115b12ae8f6622d9904788559e4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "divnix",
+        "repo": "std",
+        "type": "github"
+      }
+    },
+    "tullia": {
+      "inputs": {
+        "nix-nomad": "nix-nomad",
+        "nix2container": "nix2container",
+        "nixpkgs": [
+          "haskell-nix",
+          "nixpkgs"
+        ],
+        "std": "std"
+      },
+      "locked": {
+        "lastModified": 1666200256,
+        "narHash": "sha256-cJPS8zBu30SMhxMe7I8DWutwqMuhPsEez87y9gxMKc4=",
         "owner": "input-output-hk",
-        "repo": "typed-protocols",
-        "rev": "181601bc3d9e9d21a671ce01e0b481348b3ca104",
+        "repo": "tullia",
+        "rev": "575362c2244498e8d2c97f72861510fa72e75d44",
         "type": "github"
       },
       "original": {
         "owner": "input-output-hk",
-        "repo": "typed-protocols",
-        "rev": "181601bc3d9e9d21a671ce01e0b481348b3ca104",
+        "repo": "tullia",
+        "type": "github"
+      }
+    },
+    "utils": {
+      "locked": {
+        "lastModified": 1653893745,
+        "narHash": "sha256-0jntwV3Z8//YwuOjzhV2sgJJPt+HY6KhU7VZUL0fKZQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "1ed9fb1935d260de5fe1c2f7ee0ebaae17ed2fa1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "yants": {
+      "inputs": {
+        "nixpkgs": [
+          "haskell-nix",
+          "tullia",
+          "std",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1660507851,
+        "narHash": "sha256-BKjq7JnVuUR/xDtcv6Vm9GYGKAblisXrAgybor9hT/s=",
+        "owner": "divnix",
+        "repo": "yants",
+        "rev": "0b895ca02a8fa72bad50b454cb3e7d8a66407c96",
+        "type": "github"
+      },
+      "original": {
+        "owner": "divnix",
+        "repo": "yants",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -2,142 +2,30 @@
   description = "bot-plutus-interface";
 
   inputs = {
-    haskell-nix.url = "github:mlabs-haskell/haskell.nix";
+    haskell-nix = {
+      url = "github:input-output-hk/haskell.nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
 
     nixpkgs.follows = "haskell-nix/nixpkgs-unstable";
 
-    iohk-nix.url = "github:input-output-hk/iohk-nix";
-    iohk-nix.flake = false; # Bad Nix code
+    iohk-nix = {
+      url = "github:input-output-hk/iohk-nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
 
     flake-compat = {
       url = "github:edolstra/flake-compat";
       flake = false;
     };
 
-    # all inputs below here are for pinning with haskell.nix
-    cardano-addresses = {
-      url =
-        "github:input-output-hk/cardano-addresses/b7273a5d3c21f1a003595ebf1e1f79c28cd72513";
-      flake = false;
-    };
-    cardano-base = {
-      url =
-        "github:input-output-hk/cardano-base/0f3a867493059e650cda69e20a5cbf1ace289a57";
-      flake = false;
-    };
-    cardano-config = {
-      url =
-        "github:input-output-hk/cardano-config/1646e9167fab36c0bff82317743b96efa2d3adaa";
-      flake = false;
-    };
-    cardano-crypto = {
-      url =
-        "github:input-output-hk/cardano-crypto/f73079303f663e028288f9f4a9e08bcca39a923e";
-      flake = false;
-    };
-    cardano-ledger = {
-      url =
-        "github:input-output-hk/cardano-ledger/c7c63dabdb215ebdaed8b63274965966f2bf408f";
-      flake = false;
-    };
-    cardano-node = {
-      url =
-        "github:input-output-hk/cardano-node?ref=1.35.3";
-      flake = false; # we need it to be available in shell
-    };
-    cardano-prelude = {
-      url =
-        "github:input-output-hk/cardano-prelude/bb4ed71ba8e587f672d06edf9d2e376f4b055555";
-      flake = false;
-    };
-    cardano-wallet = {
-      url = "github:input-output-hk/cardano-wallet/18a931648550246695c790578d4a55ee2f10463e";
-      flake = false;
-    };
-    ekg-forward = {
-      url = "github:input-output-hk/ekg-forward/297cd9db5074339a2fb2e5ae7d0780debb670c63";
-      flake = false;
-    };
-    ekg-json = {
-      url = "github:vshabanov/ekg-json/00ebe7211c981686e65730b7144fbf5350462608";
-      flake = false;
-    };
-    # We don't actually need this. Removing this might make caching worse?
-    flat = {
-      url =
-        "github:Quid2/flat/ee59880f47ab835dbd73bea0847dab7869fc20d8";
-      flake = false;
-    };
-    goblins = {
-      url =
-        "github:input-output-hk/goblins/cde90a2b27f79187ca8310b6549331e59595e7ba";
-      flake = false;
-    };
-    hedgehog-extras = {
-      url = "github:input-output-hk/hedgehog-extras/714ee03a5a786a05fc57ac5d2f1c2edce4660d85";
-      flake = false;
-    };
-    hw-aeson = {
-      url = "github:haskell-works/hw-aeson/b5ef03a7d7443fcd6217ed88c335f0c411a05408";
-      flake = false;
-    };
-    iohk-monitoring-framework = {
-      url =
-        "github:input-output-hk/iohk-monitoring-framework/066f7002aac5a0efc20e49643fea45454f226caa";
-      flake = false;
-    };
-    io-sim = {
-      url =
-        "github:input-output-hk/io-sim/57e888b1894829056cb00b7b5785fdf6a74c3271";
-      flake = false;
-    };
-    optparse-applicative = {
-      url =
-        "github:input-output-hk/optparse-applicative/7497a29cb998721a9068d5725d49461f2bba0e7a";
-      flake = false;
-    };
-    ouroboros-network = {
-      url =
-        "github:input-output-hk/ouroboros-network/cb9eba406ceb2df338d8384b35c8addfe2067201";
-      flake = false;
-    };
-    plutus-core = {
-      url =
-        "github:input-output-hk/plutus/a56c96598b4b25c9e28215214d25189331087244";
-      flake = false;
-    };
-    plutus-apps = {
-      url =
-        "github:input-output-hk/plutus-apps/a2045141fc0b4f14470ebf4679c6abe40aac4db7";
-      flake = false;
-    };
-    purescript-bridge = {
-      url =
-        "github:input-output-hk/purescript-bridge/47a1f11825a0f9445e0f98792f79172efef66c00";
-      flake = false;
-    };
-    quickcheck-dynamic = {
-      url = "github:input-output-hk/quickcheck-dynamic/c272906361471d684440f76c297e29ab760f6a1e";
-      flake = false;
-    };
-    servant-purescript = {
-      url =
-        "github:input-output-hk/servant-purescript/44e7cacf109f84984cd99cd3faf185d161826963";
-      flake = false;
-    };
-    typed-protocols = {
-      url =
-        "github:input-output-hk/typed-protocols/181601bc3d9e9d21a671ce01e0b481348b3ca104";
-      flake = false;
-    };
-    Win32-network = {
-      url =
-        "github:input-output-hk/Win32-network/3825d3abf75f83f406c1f7161883c438dac7277d";
+    CHaP = {
+      url = "github:input-output-hk/cardano-haskell-packages?ref=repo";
       flake = false;
     };
   };
 
-  outputs = { self, nixpkgs, haskell-nix, iohk-nix, ... }@inputs:
+  outputs = { self, nixpkgs, haskell-nix, iohk-nix, CHaP, ... }@inputs:
     let
       defaultSystems = [ "x86_64-linux" "x86_64-darwin" ];
 
@@ -145,16 +33,14 @@
 
       nixpkgsFor = system:
         import nixpkgs {
-          overlays = [ haskell-nix.overlay (import "${iohk-nix}/overlays/crypto") ];
+          overlays = [
+            haskell-nix.overlay
+            iohk-nix.overlays.crypto
+          ];
           inherit (haskell-nix) config;
           inherit system;
         };
       nixpkgsFor' = system: import nixpkgs { inherit system; };
-
-      cabalProjectLocal = ''
-        allow-newer: *:aeson, size-based:template-haskell
-        constraints: aeson >= 2, hedgehog >= 1.1
-      '';
 
       haskellModules = [
         ({ pkgs, ... }:
@@ -166,7 +52,7 @@
               plutus-script-utils.flags.defer-plugin-errors = true;
               plutus-contract.flags.defer-plugin-errors = true;
               cardano-crypto-praos.components.library.pkgconfig = pkgs.lib.mkForce [ [ pkgs.libsodium-vrf ] ];
-              cardano-crypto-class.components.library.pkgconfig = pkgs.lib.mkForce [ [ pkgs.libsodium-vrf ] ];
+              cardano-crypto-class.components.library.pkgconfig = pkgs.lib.mkForce [ [ pkgs.libsodium-vrf pkgs.secp256k1 ] ];
               cardano-wallet-core.components.library.build-tools = [
                 pkgs.buildPackages.buildPackages.gitMinimal
               ];
@@ -178,230 +64,15 @@
         )
       ];
 
-      extraSources = [
-        {
-          src = inputs.cardano-addresses;
-          subdirs = [ "core" "command-line" ];
-        }
-        {
-          src = inputs.cardano-base;
-          subdirs = [
-            "base-deriving-via"
-            "binary"
-            "binary/test"
-            "cardano-crypto-class"
-            "cardano-crypto-praos"
-            "cardano-crypto-tests"
-            "measures"
-            "orphans-deriving-via"
-            "slotting"
-            "strict-containers"
-          ];
-        }
-        {
-          src = inputs.cardano-crypto;
-          subdirs = [ "." ];
-        }
-        {
-          src = inputs.cardano-ledger;
-          subdirs = [
-            "eras/alonzo/impl"
-            "eras/alonzo/test-suite"
-            "eras/babbage/impl"
-            "eras/byron/chain/executable-spec"
-            "eras/byron/crypto"
-            "eras/byron/crypto/test"
-            "eras/byron/ledger/executable-spec"
-            "eras/byron/ledger/impl"
-            "eras/byron/ledger/impl/test"
-            "eras/shelley/impl"
-            "eras/shelley/test-suite"
-            "eras/shelley-ma/impl"
-            "eras/shelley-ma/test-suite"
-            "libs/cardano-data"
-            "libs/cardano-ledger-core"
-            "libs/cardano-ledger-pretty"
-            "libs/cardano-protocol-tpraos"
-            "libs/vector-map"
-            "libs/non-integral"
-            "libs/set-algebra"
-            "libs/small-steps"
-            "libs/small-steps-test"
-          ];
-        }
-        {
-          src = inputs.cardano-node;
-          subdirs = [
-            "cardano-api"
-            "cardano-cli"
-            "cardano-git-rev"
-            "cardano-node"
-            "cardano-submit-api"
-            "cardano-testnet"
-            "trace-dispatcher"
-            "trace-forward"
-            "trace-resources"
-          ];
-        }
-        {
-          src = inputs.cardano-config;
-          subdirs = [ "." ];
-        }
-        {
-          src = inputs.cardano-prelude;
-          subdirs = [ "cardano-prelude" "cardano-prelude-test" ];
-        }
-        {
-          src = inputs.cardano-wallet;
-          subdirs = [
-            "lib/cli"
-            "lib/core"
-            "lib/core-integration"
-            "lib/dbvar"
-            "lib/launcher"
-            "lib/numeric"
-            "lib/shelley"
-            "lib/strict-non-empty-containers"
-            "lib/test-utils"
-            "lib/text-class"
-          ];
-        }
-        {
-          src = inputs.ekg-forward;
-          subdirs = [ "." ];
-        }
-        {
-          src = inputs.ekg-json;
-          subdirs = [ "." ];
-        }
-        {
-          src = inputs.flat;
-          subdirs = [ "." ];
-        }
-        {
-          src = inputs.goblins;
-          subdirs = [ "." ];
-        }
-        {
-          src = inputs.hedgehog-extras;
-          subdirs = [ "." ];
-        }
-        {
-          src = inputs.hw-aeson;
-          subdirs = [ "." ];
-        }
-        {
-          src = inputs.iohk-monitoring-framework;
-          subdirs = [
-            "contra-tracer"
-            "iohk-monitoring"
-            "tracer-transformers"
-            "plugins/backend-ekg"
-            "plugins/backend-aggregation"
-            "plugins/backend-monitoring"
-            "plugins/backend-trace-forwarder"
-          ];
-        }
-        {
-          src = inputs.io-sim;
-          subdirs = [
-            "io-classes"
-            "io-sim"
-            "strict-stm"
-          ];
-        }
-        {
-          src = inputs.optparse-applicative;
-          subdirs = [ "." ];
-        }
-        {
-          src = inputs.ouroboros-network;
-          subdirs = [
-            "monoidal-synchronisation"
-            "network-mux"
-            "ntp-client"
-            "ouroboros-consensus"
-            "ouroboros-consensus-byron"
-            "ouroboros-consensus-cardano"
-            "ouroboros-consensus-protocol"
-            "ouroboros-consensus-shelley"
-            "ouroboros-network"
-            "ouroboros-network-framework"
-            "ouroboros-network-testing"
-          ];
-        }
-        {
-          src = inputs.plutus-core;
-          subdirs = [
-            "plutus-core"
-            "plutus-ledger-api"
-            "plutus-tx"
-            "plutus-tx-plugin"
-            "prettyprinter-configurable"
-            "stubs/plutus-ghc-stub"
-            "word-array"
-          ];
-        }
-        {
-          src = inputs.plutus-apps;
-          subdirs = [
-            "cardano-streaming"
-            "doc"
-            "freer-extras"
-            "marconi"
-            "marconi-mamba"
-            "playground-common"
-            "pab-blockfrost"
-            "plutus-chain-index"
-            "plutus-chain-index-core"
-            "plutus-contract"
-            "plutus-contract-certification"
-            "plutus-example"
-            "plutus-ledger"
-            "plutus-ledger-constraints"
-            "plutus-pab"
-            "plutus-pab-executables"
-            "plutus-playground-server"
-            "plutus-script-utils"
-            "plutus-tx-constraints"
-            "plutus-use-cases"
-            "rewindable-index"
-            "web-ghc"
-          ];
-        }
-        {
-          src = inputs.purescript-bridge;
-          subdirs = [ "." ];
-        }
-        {
-          src = inputs.quickcheck-dynamic;
-          subdirs = [ "." ];
-        }
-        {
-          src = inputs.servant-purescript;
-          subdirs = [ "." ];
-        }
-        {
-          src = inputs.typed-protocols;
-          subdirs = [
-            "typed-protocols"
-            "typed-protocols-cborg"
-            "typed-protocols-examples"
-          ];
-        }
-        {
-          src = inputs.Win32-network;
-          subdirs = [ "." ];
-        }
-      ];
-
       projectFor = system:
         let
           pkgs = nixpkgsFor system;
           pkgs' = nixpkgsFor' system;
           project = pkgs.haskell-nix.cabalProject' {
             src = ./.;
-            inherit cabalProjectLocal extraSources;
+            inputMap = {
+              "https://input-output-hk.github.io/cardano-haskell-packages" = CHaP;
+            };
             name = "bot-plutus-interface";
             compiler-nix-name = "ghc8107";
             shell = {
@@ -447,7 +118,7 @@
 
     in
     {
-      inherit cabalProjectLocal extraSources haskellModules;
+      inherit haskellModules;
 
       project = perSystem projectFor;
       flake = perSystem (system: (projectFor system).flake { });

--- a/src/BotPlutusInterface.hs
+++ b/src/BotPlutusInterface.hs
@@ -15,4 +15,4 @@ runPAB pabConf = do
   putStrLn "Starting BotPlutusInterface server"
   state <- Server.initState
 
-  run pabConf.pcPort (Server.app @t pabConf state)
+  run (pcPort pabConf) (Server.app @t pabConf state)

--- a/src/BotPlutusInterface/Balance.hs
+++ b/src/BotPlutusInterface/Balance.hs
@@ -33,7 +33,7 @@ import BotPlutusInterface.Types (
   EstimationContext (..),
   LogLevel (Debug),
   LogType (TxBalancingLog),
-  PABConfig,
+  PABConfig (..),
   collateralTxOutRef,
   ownAddress,
   toExBudget,
@@ -302,9 +302,9 @@ hasChangeUTxO changeAddr tx =
     check txOut = txOutAddress txOut == changeAddr
 
 getExecutionUnitPrices :: PABConfig -> ExecutionUnitPrices
-getExecutionUnitPrices pabConf =
+getExecutionUnitPrices PABConfig {pcProtocolParams} =
   fromMaybe (ExecutionUnitPrices 0 0) $
-    pabConf.pcProtocolParams >>= protocolParamPrices
+    pcProtocolParams >>= protocolParamPrices
 
 getBudgetPrice :: ExecutionUnitPrices -> Ledger.ExBudget -> Integer
 getBudgetPrice (ExecutionUnitPrices cpuPrice memPrice) (Ledger.ExBudget cpuUsed memUsed) =
@@ -538,7 +538,7 @@ minus a b = a <> CApi.negateValue b
 
 ledgerMinus :: Value -> Value -> Value
 ledgerMinus x y =
-  let negativeValues = map (\(c, t, a) -> (c, t, - a)) $ Value.flattenValue y
+  let negativeValues = map (\(c, t, a) -> (c, t, -a)) $ Value.flattenValue y
    in x <> mconcat (map (uncurry3 Value.singleton) negativeValues)
 
 isValueNat :: CApi.Value -> Bool

--- a/src/BotPlutusInterface/CardanoCLI.hs
+++ b/src/BotPlutusInterface/CardanoCLI.hs
@@ -136,7 +136,7 @@ calculateMinFee pabConf tx =
               , ["--tx-in-count", showText $ length $ txInputs tx]
               , ["--tx-out-count", showText $ length $ txOutputs tx]
               , ["--witness-count", showText $ length $ txSignatures tx]
-              , ["--protocol-params-file", (pcProtocolParamsFile pabConf)]
+              , ["--protocol-params-file", pcProtocolParamsFile pabConf]
               , networkOpt pabConf
               ]
         , cmdOutParser = mapLeft Text.pack . parseOnly UtxoParser.feeParser . Text.pack
@@ -187,7 +187,7 @@ buildTx pabConf txBudget tx = do
           , requiredSigners
           , ["--fee", showText . getLovelace . fromValue $ txFee tx]
           , mconcat
-              [ ["--protocol-params-file", (pcProtocolParamsFile pabConf)]
+              [ ["--protocol-params-file", pcProtocolParamsFile pabConf]
               , ["--out-file", txFilePath pabConf "raw" (txId tx)]
               ]
           ]

--- a/src/BotPlutusInterface/CardanoCLI.hs
+++ b/src/BotPlutusInterface/CardanoCLI.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE ViewPatterns #-}
 
 module BotPlutusInterface.CardanoCLI (
@@ -26,7 +27,7 @@ import BotPlutusInterface.Helpers (isZero)
 import BotPlutusInterface.Types (
   EstimationContext (ecUtxos),
   MintBudgets,
-  PABConfig,
+  PABConfig (..),
   SpendBudgets,
   Tip,
   TxBudget,
@@ -135,7 +136,7 @@ calculateMinFee pabConf tx =
               , ["--tx-in-count", showText $ length $ txInputs tx]
               , ["--tx-out-count", showText $ length $ txOutputs tx]
               , ["--witness-count", showText $ length $ txSignatures tx]
-              , ["--protocol-params-file", pabConf.pcProtocolParamsFile]
+              , ["--protocol-params-file", (pcProtocolParamsFile pabConf)]
               , networkOpt pabConf
               ]
         , cmdOutParser = mapLeft Text.pack . parseOnly UtxoParser.feeParser . Text.pack
@@ -186,7 +187,7 @@ buildTx pabConf txBudget tx = do
           , requiredSigners
           , ["--fee", showText . getLovelace . fromValue $ txFee tx]
           , mconcat
-              [ ["--protocol-params-file", pabConf.pcProtocolParamsFile]
+              [ ["--protocol-params-file", (pcProtocolParamsFile pabConf)]
               , ["--out-file", txFilePath pabConf "raw" (txId tx)]
               ]
           ]
@@ -398,7 +399,7 @@ txOutOpts pabConf datums =
             else ["--tx-out-datum-hash", encodeByteString dh]
 
 networkOpt :: PABConfig -> [Text]
-networkOpt pabConf = case pabConf.pcNetwork of
+networkOpt PABConfig {pcNetwork} = case pcNetwork of
   Testnet (NetworkMagic t) -> ["--testnet-magic", showText t]
   Mainnet -> ["--mainnet"]
 

--- a/src/BotPlutusInterface/ChainIndex.hs
+++ b/src/BotPlutusInterface/ChainIndex.hs
@@ -6,7 +6,7 @@ module BotPlutusInterface.ChainIndex (
 
 import BotPlutusInterface.Types (
   ContractEnvironment (ContractEnvironment, cePABConfig),
-  PABConfig,
+  PABConfig (pcChainIndexUrl),
  )
 import Data.Kind (Type)
 import Network.HTTP.Client (
@@ -90,7 +90,7 @@ handleChainIndexReq contractEnv@ContractEnvironment {cePABConfig} =
 chainIndexQuery' :: forall (a :: Type). PABConfig -> ClientM a -> IO (Either ClientError a)
 chainIndexQuery' pabConf endpoint = do
   manager' <- newManager defaultManagerSettings {managerResponseTimeout = responseTimeoutNone}
-  runClientM endpoint $ mkClientEnv manager' pabConf.pcChainIndexUrl
+  runClientM endpoint $ mkClientEnv manager' (pcChainIndexUrl pabConf)
 
 chainIndexQueryMany :: forall (a :: Type). PABConfig -> ClientM a -> IO a
 chainIndexQueryMany pabConf endpoint =
@@ -108,14 +108,14 @@ chainIndexQueryOne pabConf endpoint = do
 
 -- | Query for utxo's.
 chainIndexUtxoQuery :: forall (w :: Type). ContractEnvironment w -> ClientM UtxosResponse -> IO UtxosResponse
-chainIndexUtxoQuery contractEnv query = do
+chainIndexUtxoQuery ContractEnvironment {cePABConfig} query = do
   chainIndexQueryMany
-    contractEnv.cePABConfig
+    cePABConfig
     query
 
 -- | Query for txo's.
 chainIndexTxoQuery :: forall (w :: Type). ContractEnvironment w -> ClientM TxosResponse -> IO TxosResponse
-chainIndexTxoQuery contractEnv query = do
+chainIndexTxoQuery ContractEnvironment {cePABConfig} query = do
   chainIndexQueryMany
-    contractEnv.cePABConfig
+    cePABConfig
     query

--- a/src/BotPlutusInterface/Contract.hs
+++ b/src/BotPlutusInterface/Contract.hs
@@ -305,7 +305,7 @@ awaitTxStatusChange contractEnv txId = do
   printBpiLog @w (Debug [PABLog]) $ pretty $ "Awaiting status change for " ++ show txId
 
   let txStatusPolling = pcTxStatusPolling (cePABConfig contractEnv)
-      pollInterval = fromIntegral $ spInterval $ txStatusPolling
+      pollInterval = fromIntegral $ spInterval txStatusPolling
       pollTimeout = spBlocksTimeOut txStatusPolling
       cutOffBlock = checkStartedBlock + fromIntegral pollTimeout
 
@@ -440,7 +440,7 @@ writeBalancedTx contractEnv cardanoTx = do
               ]
             else ["Missing Signatories (pkh):" <+> pretty (Text.unwords (map pkhToText missingPubKeys))]
 
-    when ((pcCollectStats pabConf) && fullySignable) $
+    when (pcCollectStats pabConf && fullySignable) $
       lift $ saveBudget @w (Tx.txId tx') txBudget
 
     when (not (pcDryRun pabConf) && fullySignable) $ do
@@ -489,7 +489,7 @@ awaitSlot contractEnv s@(Slot n) = do
   tip <- CardanoCLI.queryTip @w $ cePABConfig contractEnv
   case tip of
     Right tip'
-      | n < (slot tip') -> pure $ Slot (slot tip')
+      | n < slot tip' -> pure $ Slot (slot tip')
     _ -> awaitSlot contractEnv s
 
 {- | Wait at least until the given time. Uses the awaitSlot under the hood, so the same constraints
@@ -611,7 +611,7 @@ makeCollateral ::
 makeCollateral cEnv = runEitherT $ do
   lift $ printBpiLog @w (Notice [CollateralLog]) "Making collateral"
 
-  let pabConf = (cePABConfig cEnv)
+  let pabConf = cePABConfig cEnv
 
   -- TODO: Enforce existence of pparams at the beginning
   pparams <- maybe (error "Must have ProtocolParameters in PABConfig") return (pcProtocolParams pabConf)

--- a/src/BotPlutusInterface/Effects.hs
+++ b/src/BotPlutusInterface/Effects.hs
@@ -166,13 +166,13 @@ handlePABEffect contractEnv@ContractEnvironment {cePABConfig} =
     ( \case
         CallCommand shellArgs -> do
           print (cmdName shellArgs, cmdArgs shellArgs)
-          case (pcCliLocation cePABConfig) of
+          case pcCliLocation cePABConfig of
             Local -> callLocalCommand shellArgs
             Remote ipAddr -> callRemoteCommand ipAddr shellArgs
         CreateDirectoryIfMissing createParents filePath ->
           Directory.createDirectoryIfMissing createParents filePath
         CreateDirectoryIfMissingCLI createParents filePath ->
-          case (pcCliLocation cePABConfig) of
+          case pcCliLocation cePABConfig of
             Local -> Directory.createDirectoryIfMissing createParents filePath
             Remote ipAddr -> createDirectoryIfMissingRemote ipAddr createParents filePath
         PrintLog logCtx logLevel msg -> do
@@ -199,7 +199,7 @@ handlePABEffect contractEnv@ContractEnvironment {cePABConfig} =
           CApi.writeFileTextEnvelope filepath envelopeDescr contents
         ListDirectory filepath -> Directory.listDirectory filepath
         UploadDir dir ->
-          case (pcCliLocation cePABConfig) of
+          case pcCliLocation cePABConfig of
             Local -> pure ()
             Remote ipAddr ->
               void $ readProcess "scp" ["-r", Text.unpack dir, Text.unpack $ ipAddr <> ":$HOME"] ""

--- a/src/BotPlutusInterface/ExBudget.hs
+++ b/src/BotPlutusInterface/ExBudget.hs
@@ -8,7 +8,7 @@ import BotPlutusInterface.Types (
   BudgetEstimationError (..),
   EstimationContext (..),
   MintBudgets,
-  PABConfig,
+  PABConfig (pcBudgetMultiplier),
   SpendBudgets,
   SystemContext (..),
   TxBudget (TxBudget),
@@ -43,12 +43,12 @@ estimateBudget pabConf eCtx txFile = do
     do
       body <- txBody
       budget <- getExUnits eCtx body
-      let pparams = eCtx.ecSystemContext.scParams
+      let pparams = scParams (ecSystemContext eCtx)
       maxUnits <-
         maybeToEither (BudgetEstimationError "Missing max units in parameters") $
           protocolParamMaxTxExUnits pparams
 
-      scaledBudget <- getScaledBudget maxUnits pabConf.pcBudgetMultiplier budget
+      scaledBudget <- getScaledBudget maxUnits (pcBudgetMultiplier pabConf) budget
 
       (spendingBudgets, policyBudgets) <- mkBudgetMaps scaledBudget body
 

--- a/src/BotPlutusInterface/Server.hs
+++ b/src/BotPlutusInterface/Server.hs
@@ -207,7 +207,7 @@ handleContractActivityChange contractInstanceID prevState currentState =
   where
     activityChange =
       if (csActivity <$> prevState) /= Just (csActivity currentState)
-        then case (csActivity currentState) of
+        then case csActivity currentState of
           Done maybeError -> do
             Just $ InstanceUpdate contractInstanceID $ ContractFinished maybeError
           _ -> Nothing

--- a/src/BotPlutusInterface/Types.hs
+++ b/src/BotPlutusInterface/Types.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE TemplateHaskell #-}
 
@@ -89,7 +90,7 @@ data PABConfig = PABConfig
     pcScriptFileDir :: !Text
   , -- | Directory name of the signing key files
     pcSigningKeyFileDir :: !Text
-  , -- | Directory name of the transaction files
+  , -- | Directory name of the transaction file
     pcTxFileDir :: !Text
   , -- | Protocol params file location relative to the cardano-cli working directory (needed for the cli)
     pcProtocolParamsFile :: !Text
@@ -118,11 +119,11 @@ collateralValue :: PABConfig -> Ledger.Value
 collateralValue = Ada.lovelaceValueOf . toInteger . pcCollateralSize
 
 ownAddress :: PABConfig -> Either Ledger.ToCardanoError (AddressInEra BabbageEra)
-ownAddress pabConf =
-  toCardanoAddressInEra pabConf.pcNetwork $
+ownAddress PABConfig {pcNetwork, pcOwnPubKeyHash, pcOwnStakePubKeyHash} =
+  toCardanoAddressInEra pcNetwork $
     Ledger.pubKeyHashAddress
-      (Ledger.PaymentPubKeyHash pabConf.pcOwnPubKeyHash)
-      pabConf.pcOwnStakePubKeyHash
+      (Ledger.PaymentPubKeyHash pcOwnPubKeyHash)
+      (Ledger.stakePubKeyHashCredential <$> pcOwnStakePubKeyHash)
 
 {- | Settings for `Contract.awaitTxStatusChange` implementation.
  See also `BotPlutusInterface.Contract.awaitTxStatusChange`

--- a/test/Spec/BotPlutusInterface/ContractStats.hs
+++ b/test/Spec/BotPlutusInterface/ContractStats.hs
@@ -7,7 +7,7 @@ import Control.Lens ((%~), (&), (.~), (^.))
 import Data.Default (def)
 import Data.Text (Text)
 import Data.Text qualified as Text
-import Ledger (ChainIndexTxOut (PublicKeyChainIndexTxOut), PaymentPubKeyHash (unPaymentPubKeyHash))
+import Ledger (DecoratedTxOut (PublicKeyDecoratedTxOut), PaymentPubKeyHash (unPaymentPubKeyHash))
 import Ledger.Ada qualified as Ada
 import Ledger.Constraints qualified as Constraints
 import Ledger.Tx (CardanoTx, TxOutRef (TxOutRef))
@@ -21,7 +21,7 @@ import Spec.MockContract (
   mockBudget,
   paymentPkh1,
   paymentPkh2,
-  pkhAddr1,
+  pkh1,
   runContractPure,
   statsUpdates,
   updatePabConfig,
@@ -42,7 +42,7 @@ tests =
 budgetSavingEnabled :: Assertion
 budgetSavingEnabled = do
   let txOutRef = TxOutRef "e406b0cf676fc2b1a9edb0617f259ad025c20ea6f0333820aa7cef1bfe7302e5" 0
-      txOut = PublicKeyChainIndexTxOut pkhAddr1 (Ada.adaValueOf 50) Nothing Nothing
+      txOut = PublicKeyDecoratedTxOut pkh1 Nothing (Ada.adaValueOf 50) Nothing Nothing
       initState =
         def & utxos .~ [(txOutRef, txOut)]
           & contractEnv
@@ -62,7 +62,7 @@ budgetSavingEnabled = do
 budgetSavingDisabled :: Assertion
 budgetSavingDisabled = do
   let txOutRef = TxOutRef "e406b0cf676fc2b1a9edb0617f259ad025c20ea6f0333820aa7cef1bfe7302e5" 0
-      txOut = PublicKeyChainIndexTxOut pkhAddr1 (Ada.adaValueOf 50) Nothing Nothing
+      txOut = PublicKeyDecoratedTxOut pkh1 Nothing (Ada.adaValueOf 50) Nothing Nothing
       initState = def & utxos .~ [(txOutRef, txOut)]
 
       contract :: Contract () (Endpoint "SendAda" ()) Text CardanoTx

--- a/test/Spec/BotPlutusInterface/TxStatusChange.hs
+++ b/test/Spec/BotPlutusInterface/TxStatusChange.hs
@@ -9,10 +9,10 @@ import Control.Lens (views, (%~), (&), (.~), (^.))
 import Data.Default (def)
 import Data.Text (Text)
 import Data.Text qualified as Text
-import Ledger (ChainIndexTxOut (PublicKeyChainIndexTxOut), PaymentPubKeyHash (unPaymentPubKeyHash), getCardanoTxId)
+import Ledger (PaymentPubKeyHash (unPaymentPubKeyHash), getCardanoTxId)
 import Ledger.Ada qualified as Ada
 import Ledger.Constraints qualified as Constraints
-import Ledger.Tx (TxOutRef (TxOutRef))
+import Ledger.Tx (DecoratedTxOut (PublicKeyDecoratedTxOut), TxOutRef (TxOutRef))
 import Plutus.ChainIndex (RollbackState (Unknown), Tip (TipAtGenesis), TxStatus)
 import Plutus.ChainIndex.Types (Tip (Tip))
 import Plutus.Contract (
@@ -28,7 +28,7 @@ import Spec.MockContract (
   nonExistingTxId,
   paymentPkh1,
   paymentPkh2,
-  pkhAddr1,
+  pkh1,
   runContractPure,
   tip,
   updatePabConfig,
@@ -49,7 +49,7 @@ tests =
 testTxFoundAndConfirmed :: Assertion
 testTxFoundAndConfirmed = do
   let txOutRef = TxOutRef "e406b0cf676fc2b1a9edb0617f259ad025c20ea6f0333820aa7cef1bfe7302e5" 0
-      txOut = PublicKeyChainIndexTxOut pkhAddr1 (Ada.adaValueOf 50) Nothing Nothing
+      txOut = PublicKeyDecoratedTxOut pkh1 Nothing (Ada.adaValueOf 50) Nothing Nothing
       initState =
         def & utxos .~ [(txOutRef, txOut)]
           & contractEnv

--- a/test/Spec/MockContract.hs
+++ b/test/Spec/MockContract.hs
@@ -502,7 +502,7 @@ mockQueryUtxo :: forall (w :: Type). Text -> MockContract w String
 mockQueryUtxo addr = do
   state <- get @(MockContractState w)
 
-  let network = (state ^. contractEnv).cePABConfig.pcNetwork
+  let network = (state ^. contractEnv) . cePABConfig . pcNetwork
   pure $
     mockQueryUtxoOut $
       filter


### PR DESCRIPTION
- Switch to upstream haskell.nix and cardano-haskell-packages
- Remove record dot syntax and update codebase (because of a haskell.nix bug https://github.com/input-output-hk/haskell.nix/issues/1762)
- Update codebase following plutus-apps api changes
